### PR TITLE
Wait for loadbalancers when cycling instances

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Changelog for Touchdown
 0.0.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- asg: If an ASG is connected to an ELB, consider the ELB health when
+  scaling/descaling during a deployment.
 
 
 0.0.14 (2015-05-28)

--- a/touchdown/aws/ec2/auto_scaling_group.py
+++ b/touchdown/aws/ec2/auto_scaling_group.py
@@ -228,8 +228,9 @@ class Apply(SimpleApply, Describe):
         for change in super(Apply, self).update_object():
             yield change
 
-        if not self.object and self.resource.min_size and self.resource.min_size > 0:
-            yield WaitForHealthy(self)
+        if self.resource.min_size and self.resource.min_size > 0:
+            if len(self.object.get("Instances", [])) < self.resource.min_size:
+                yield WaitForHealthy(self)
 
         launch_config_name = self.runner.get_plan(self.resource.launch_configuration).resource_id
         instances = []


### PR DESCRIPTION
Considers the ELB health when cycling an autoscaling group.

This fixes the problem where an ec2 instance is reported as healthy by the ASG but isn't "in service" yet. Previously this meant it terminated the old instance before the new instance was in service, causing downtime.