### PR TITLE
Add support for posting notifications to slack

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -25,4 +25,5 @@ VPC at Amazon with a subnet your ``Touchdownfile`` would contain::
 .. toctree::
 
    aws/index
-   fuselage
+   provisioner/index
+   notifications/index

--- a/docs/config/notifications/index.rst
+++ b/docs/config/notifications/index.rst
@@ -1,0 +1,9 @@
+.. currentmodule: touchdown.notifications
+
+Notifications
+=============
+
+.. toctree::
+   :glob:
+
+   *

--- a/docs/config/notifications/slack.rst
+++ b/docs/config/notifications/slack.rst
@@ -59,7 +59,7 @@ Advanced notifications
 
 .. class:: Attachment
 
-    fallback
+    .. attribute:: fallback
 
         The fallback message to show if the advanced notification is not shown
         (for example in mobile notifications or on IRC). This is required.

--- a/docs/config/notifications/slack.rst
+++ b/docs/config/notifications/slack.rst
@@ -1,0 +1,196 @@
+Slack notifications
+===================
+
+To get a slack notification you'll need to add the "Incoming Webhook" to your
+account. You'll be given a URL that looks like this::
+
+    https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+
+Treat this URL as one of your application secrets.
+
+.. class:: SlackNotification
+
+    You can send a notification from the workspace::
+
+        script = workspace.add_slack_notification(
+            webhook="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+            channel="#touchdown",
+            text="Hello from touchdown",
+        )
+
+    .. attribute:: webhook
+
+        A ``hooks.slack.com`` url to post notifications to.
+
+    .. attribute:: username
+
+        The username of the bot that posts this in the channel. Messages will
+        appear to come from this user, even if there isn't a user with this
+        name. The default user is ``yaybu``.
+
+    .. attribute:: icon_url
+
+        A url to fetch an avatar from for this bot user.
+
+    .. attribute:: icon_emoji
+
+        A slack emoji to use as an avatar, for example ``:ghost:``. Should not
+        be used at the same time as ``icon_url``.
+
+    .. attribute:: channel
+
+        The channel to post in. By default the integration will post in the
+        channel defined by the hook itself. You can set it to a ``#channel`` or
+        ``@user`` that you want to send notifications to.
+
+    .. attribute:: text
+
+        A message to send to the channel. You can use a touchdown serializer
+        to set this based on other resources you have defined.
+
+    .. attribute:: attachments
+
+        A list of :class:`~Attachment`. These allow construction of prettier and
+        more informative notifications.
+
+
+Advanced notifications
+----------------------
+
+.. class:: Attachment
+
+    fallback
+
+        The fallback message to show if the advanced notification is not shown
+        (for example in mobile notifications or on IRC). This is required.
+
+    .. attribute:: color
+
+        An optional value that can either be one of ``good``, ``warning``,
+        ``danger``, or any hex color code (eg. ``#439FE0``). This value is used
+        to color the border along the left side of the message attachment.
+
+    .. attribute:: pretext
+
+        Optional text that appears above the message attachment block.
+
+    .. attribute:: author_name
+
+        Small text used to display the author's name.
+
+    .. attribute:: author_link
+
+        A valid URL that will hyperlink the author_name text mentioned above.
+        Will only work if author_name is present.
+
+    .. attribute:: author_icon
+
+        A valid URL that displays a small 16x16px image to the left of the
+        author_name text. Will only work if author_name is present.
+
+    .. attribute:: title
+
+        The title is displayed as larger, bold text near the top of a message
+        attachment.
+
+    .. attribute:: title_link
+
+        If set, the ``title`` text will appear hyperlinked.
+
+    .. attribute:: text
+
+        This is the main text in a message attachment, and can contain standard
+        message markup. The content will automatically collapse if it contains
+        700+ characters or 5+ linebreaks, and will display a "Show more..."
+        link to expand the content.
+
+    .. attribute:: fields
+
+        Metadata to show in a table inside the message attachment. Represented
+        as a list of dictionaries::
+
+            workspace.add_slack_notification(
+                #.. snip ..
+                attachments=[{
+                    "fallback": "A deployment to production just completed",
+                    "fields": [{
+                        "title": "Environment",
+                        "value": "production",
+                        "short": True,
+                    }]
+                }]
+            )
+
+        The fields are:
+
+        ``title``
+            Shown as a bold heading above the ``value`` text. It cannot contain
+            markup and will be escaped for you.
+        ``value``
+            The text value of the field. It may contain standard message markup
+            and must be escaped as normal. May be multi-line.
+        ``short``
+            An optional flag indicating whether the value is short enough to be
+            displayed side-by-side with other values.
+
+    .. attribute:: image_url
+
+        A valid URL to an image file that will be displayed inside a message
+        attachment. Slack currently supports the following formats: GIF, JPEG,
+        PNG, and BMP.
+
+        Large images will be resized to a maximum width of 400px or a maximum
+        height of 500px, while still maintaining the original aspect ratio.
+
+    .. attribute:: thumb_url
+
+        A valid URL to an image file that will be displayed as a thumbnail on
+        the right side of a message attachment. Slack currently supports the
+        following formats: GIF, JPEG, PNG, and BMP.
+
+        The thumbnail's longest dimension will be scaled down to 75px while
+        maintaining the aspect ratio of the image. The filesize of the image
+        must also be less than 500 KB.
+
+    .. attribute:: markdown_in
+
+        Fields which have markdown in them that needs rendering. For example if
+        ``text`` contains markdown you must do::
+
+            workspace.add_slack_notification(
+                attachments=[{
+                    "text": "A deployment to ``production`` just completed",
+                    "markdown_in": ["text"],
+                }]
+            )
+
+Examples
+--------
+
+For a post deployment notification that includes a changelog snippet you can
+do something like::
+
+    workspace.add_slack_notification(
+        webhook="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+        channel="#touchdown",
+        attachments=[{
+            "fallback": "Deployment of '1.3' to 'production' completed",
+            "title": "Deployment by user1 completed",
+            "text": "\n".join([
+                "```",
+                "- Added a new foobar <user1>",
+                "- Fixed the frobnicator <user2>"
+                "```",
+            ]),
+            "markdown_in": ["text"],
+            "fields": [{
+                "title": "Environment",
+                "value": "production",
+                "short": True,
+            }, {
+                "title": "Version",
+                "value": "1.3",
+                "short": True,
+            }],
+        }],
+    )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,9 @@ Resources
    :doc:`Deploying scripts <config/provisioner/bash>` |
    :doc:`Deploying fuselage bundles <config/provisioner/fuselage>`
 
+ * **Notifications:**
+   :doc:`Slack notifications <config/notifications/slack>`
+
 
 Getting help
 ============

--- a/touchdown/core/diff.py
+++ b/touchdown/core/diff.py
@@ -52,7 +52,8 @@ class DiffSet(object):
             self.build_diffs()
 
     def build_diffs(self):
-        for name, field in self.local.meta.iter_fields_in_order():
+        for field in self.local.meta.iter_fields_in_order():
+            name = field.name
             arg = field.argument
             if not field.present(self.local):
                 continue

--- a/touchdown/core/diff.py
+++ b/touchdown/core/diff.py
@@ -52,7 +52,7 @@ class DiffSet(object):
             self.build_diffs()
 
     def build_diffs(self):
-        for name, field in self.local.fields:
+        for name, field in self.local.meta.iter_fields_in_order():
             arg = field.argument
             if not field.present(self.local):
                 continue

--- a/touchdown/core/resource.py
+++ b/touchdown/core/resource.py
@@ -168,12 +168,8 @@ class Resource(six.with_metaclass(ResourceType)):
                 setattr(self, field.name, kwargs[field.name])
 
     @property
-    def fields(self):
-        return list((field.name, field) for field in self.meta.iter_fields_in_order())
-
-    @property
     def arguments(self):
-        return list((name, field.argument) for (name, field) in self.fields)
+        return list((name, field.argument) for (name, field) in self.meta.iter_fields_in_order())
 
     @property
     def workspace(self):

--- a/touchdown/core/serializers.py
+++ b/touchdown/core/serializers.py
@@ -317,18 +317,18 @@ class Resource(Dict):
             for name, serializer in getattr(object, "extra_serializers", {}).items():
                 kwargs[name] = serializer
 
-        for argument_name, field in object.fields:
+        for field in object.meta.iter_fields_in_order():
             value = field.get_value(object)
             if self.should_ignore_field(field, value):
                 continue
 
-            if hasattr(object, "serialize_" + argument_name):
-                serializer = Expression(getattr(object, "serialize_" + argument_name))
+            if hasattr(object, "serialize_" + field.name):
+                serializer = Expression(getattr(object, "serialize_" + field.name))
             else:
                 serializer = field.argument.serializer
 
             kwargs[field.argument.field] = Context(
-                Argument(argument_name, field),
+                Argument(field.name, field),
                 serializer,
             )
 

--- a/touchdown/notifications/__init__.py
+++ b/touchdown/notifications/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Isotoma Limited
+# Copyright 2015 Isotoma Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import touchdown.aws  # noqa
-import touchdown.provisioner  # noqa
-import touchdown.ssh  # noqa
-import touchdown.goals  # noqa
-import touchdown.notifications  # noqa
-
-from touchdown.core import Workspace
+from .slack import SlackNotification
 
 __all__ = [
-    "Workspace",
+    "SlackNotification",
 ]

--- a/touchdown/notifications/slack.py
+++ b/touchdown/notifications/slack.py
@@ -17,6 +17,39 @@ import requests
 from touchdown.core import argument, action, errors, plan, resource, serializers, workspace
 
 
+class Field(resource.Resource):
+
+    resource_name = "slack_attachment_field"
+
+    title = argument.String(field="title")
+    value = argument.String(field="value")
+    short = argument.Boolean(field="short")
+
+
+class Attachment(resource.Resource):
+
+    resource_name = "slack_attachment"
+
+    fallback = argument.String(field="fallback")
+    color = argument.String(field="color")
+    pretext = argument.String(field="pretext")
+    author_name = argument.String(field="author_name")
+    author_link = argument.String(field="author_link")
+    author_icon = argument.String(field="author_icon")
+
+    title = argument.String(field="title")
+    title_link = argument.String(field="title_link")
+
+    text = argument.String(field="text")
+
+    fields = argument.ResourceList(Field, field="fields", serializer=serializers.List(serializers.Resource(), skip_empty=True))
+
+    image_url = argument.String(field="image_url")
+    thumb_url = argument.String(field="thumb_url")
+
+    markdown_in = argument.List(field="mrkdwn_in")
+
+
 class SlackNotification(resource.Resource):
 
     resource_name = "slack_notification"
@@ -27,6 +60,7 @@ class SlackNotification(resource.Resource):
     icon_url = argument.String(default="https://avatars3.githubusercontent.com/u/5338681", field="icon_url")
     icon_emoji = argument.String(field="icon_emoji")
     text = argument.String(field="text")
+    attachments = argument.ResourceList(Attachment, field="attachments", serializer=serializers.List(serializers.Resource(), skip_empty=True))
 
     root = argument.Resource(workspace.Workspace)
 

--- a/touchdown/notifications/slack.py
+++ b/touchdown/notifications/slack.py
@@ -1,0 +1,55 @@
+# Copyright 2015 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+
+from touchdown.core import argument, action, errors, plan, resource, serializers, workspace
+
+
+class SlackNotification(resource.Resource):
+
+    resource_name = "slack_notification"
+
+    webhook = argument.String()
+    username = argument.String(default="yaybu", field="username")
+    channel = argument.String(field="channel")
+    icon_url = argument.String(default="https://avatars3.githubusercontent.com/u/5338681", field="icon_url")
+    icon_emoji = argument.String(field="icon_emoji")
+    text = argument.String(field="text")
+
+    root = argument.Resource(workspace.Workspace)
+
+
+class SlackNotificationAction(action.Action):
+
+    @property
+    def description(self):
+        yield "Post slack notification to {}".format(self.resource.channel)
+
+    def run(self):
+        response = requests.post(
+            self.resource.webhook,
+            data=serializers.Json(serializers.Resource()).render(self.runner, self.resource)
+        )
+        if response.status_code != 200:
+            raise errors.Error("Error submitting notification: {}".format(response.text))
+
+
+class Apply(plan.Plan):
+
+    name = "apply"
+    resource = SlackNotification
+
+    def get_actions(self):
+        yield SlackNotificationAction(self)


### PR DESCRIPTION
This defaults to using the yaybu logo (and yaybu username). It'll also post in the default chatroom for the webhook by default, but you can set another user or room if you want:

```python
workspace.add_slack_notification(
    webhook="https://hooks.slack.com/services/xxxx/xxxx/xxxxxx",
    channel="@Jc2k",
    text="Hello from touchdown",
)
```

```text``` can be a serializer so you can refer to the AMI id that it just created or something like that.