### PR TITLE
[WIP] Add a 'touchdown ssh' command

### DIFF
--- a/docs/cli/scp.rst
+++ b/docs/cli/scp.rst
@@ -1,0 +1,34 @@
+scp
+===
+
+If you have defined an explicit ssh connection in your config::
+
+    aws.add_auto_scaling_group(
+        name=name,
+        launch_configuration=...,
+        <SNIP>,
+    )
+
+    workspace.add_ssh_connection(
+        name="worker",
+        instance="worker",
+        username="ubuntu",
+        private_key=open('foo.pem').read(),
+    )
+
+Then you could scp files to and from it with::
+
+    touchdown scp worker foo.txt remote:
+
+And in reverse:
+
+    touchdown scp worker remote:foo.txt /tmp/
+
+
+You can use the following arguments:
+
+.. program:: touchdown scp BOX
+
+.. argument:: BOX
+
+    The target you want to scp to/from.

--- a/docs/cli/scp.rst
+++ b/docs/cli/scp.rst
@@ -22,7 +22,7 @@ Then you could scp files to and from it with::
 
 And in reverse:
 
-    touchdown scp worker remote:foo.txt /tmp/
+    touchdown scp worker:foo.txt /tmp/
 
 
 You can use the following arguments:

--- a/docs/cli/scp.rst
+++ b/docs/cli/scp.rst
@@ -18,7 +18,7 @@ If you have defined an explicit ssh connection in your config::
 
 Then you could scp files to and from it with::
 
-    touchdown scp worker foo.txt remote:
+    touchdown scp foo.txt worker:
 
 And in reverse:
 

--- a/docs/cli/ssh.rst
+++ b/docs/cli/ssh.rst
@@ -1,0 +1,30 @@
+SSH
+===
+
+If you have defined an explicit ssh connection in your config::
+
+    aws.add_auto_scaling_group(
+        name=name,
+        launch_configuration=...,
+        <SNIP>,
+    )
+
+    workspace.add_ssh_connection(
+        name="worker",
+        instance="worker",
+        username="ubuntu",
+        private_key=open('foo.pem').read(),
+    )
+
+Then you could ssh into a random instead in the ``worker`` autoscaling group
+with::
+
+    touchdown ssh worker
+
+You can use the following arguments:
+
+.. program:: touchdown ssh BOX
+
+.. argument:: BOX
+
+    The target you want to SSH into.

--- a/docs/cli/touchdown.rst
+++ b/docs/cli/touchdown.rst
@@ -99,4 +99,5 @@ There are a bunch of commands you can run against your Touchdown config:
    tail
    rollback
    snapshot
+   ssh
    dot

--- a/docs/cli/touchdown.rst
+++ b/docs/cli/touchdown.rst
@@ -98,6 +98,7 @@ There are a bunch of commands you can run against your Touchdown config:
    get_signin_url
    tail
    rollback
+   scp
    snapshot
    ssh
    dot

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Getting started
    :doc:`Viewing logs <cli/tail>` |
    :doc:`Snapshotting your data <cli/snapshot>` |
    :doc:`Rolling back data <cli/rollback>` |
+   :doc:`SSHing to your infrastructure <cli/ssh>` |
    :doc:`Estimating infrastructure cost <cli/cost>` |
    :doc:`Generating graphs <cli/dot>`
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Getting started
    :doc:`Snapshotting your data <cli/snapshot>` |
    :doc:`Rolling back data <cli/rollback>` |
    :doc:`SSHing to your infrastructure <cli/ssh>` |
+   :doc:`SCPing to/from your infrastructure <cli/scp>` |
    :doc:`Estimating infrastructure cost <cli/cost>` |
    :doc:`Generating graphs <cli/dot>`
 

--- a/touchdown/aws/ec2/auto_scaling_group.py
+++ b/touchdown/aws/ec2/auto_scaling_group.py
@@ -298,7 +298,8 @@ class Instance(ssh.Instance):
 
     def get_instances(self, runner):
         plan = runner.get_plan(self.adapts)
-        if len(plan.object.get("Instances", [])) == 0:
+        obj = plan.describe_object()
+        if len(obj.get("Instances", [])) == 0:
             raise errors.Error("No instances currently running in group {}".format(self.adapts))
 
         # Annoyingly we have to get antother client (different API) to get info
@@ -307,7 +308,7 @@ class Instance(ssh.Instance):
 
         reservations = client.describe_instances(
             InstanceIds=[
-                i["InstanceId"] for i in plan.object.get("Instances", [])
+                i["InstanceId"] for i in obj.get("Instances", [])
             ],
         ).get("Reservations", [])
 

--- a/touchdown/goals/__init__.py
+++ b/touchdown/goals/__init__.py
@@ -18,6 +18,7 @@ from .destroy import Destroy
 from .dot import Dot
 from .get_signin_url import GetSigninUrl
 from .rollback import Rollback
+from .scp import Scp
 from .snapshot import Snapshot
 from .ssh import Ssh
 from .tail import Tail
@@ -30,6 +31,7 @@ __all__ = [
     "Dot",
     "GetSigninUrl",
     "Rollback",
+    "Scp",
     "Snapshot",
     "Ssh",
     "Tail",

--- a/touchdown/goals/__init__.py
+++ b/touchdown/goals/__init__.py
@@ -19,6 +19,7 @@ from .dot import Dot
 from .get_signin_url import GetSigninUrl
 from .rollback import Rollback
 from .snapshot import Snapshot
+from .ssh import Ssh
 from .tail import Tail
 
 
@@ -30,5 +31,6 @@ __all__ = [
     "GetSigninUrl",
     "Rollback",
     "Snapshot",
+    "Ssh",
     "Tail",
 ]

--- a/touchdown/goals/scp.py
+++ b/touchdown/goals/scp.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
-
 from touchdown.core import errors
 from touchdown.core.goals import Goal, register
 

--- a/touchdown/goals/scp.py
+++ b/touchdown/goals/scp.py
@@ -1,0 +1,52 @@
+# Copyright 2015 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+from touchdown.core import errors
+from touchdown.core.goals import Goal, register
+
+
+class Scp(Goal):
+
+    """ SCP files to and from infrastructure managed by touchdown """
+
+    name = "scp"
+    mutator = False
+
+    def get_plan_class(self, resource):
+        plan_class = resource.meta.get_plan("scp")
+        if not plan_class:
+            plan_class = resource.meta.get_plan("describe")
+        if not plan_class:
+            plan_class = resource.meta.get_plan("null")
+        return plan_class
+
+    @classmethod
+    def setup_argparse(cls, parser):
+        parser.add_argument(
+            "box",
+            metavar="BOX",
+            type=str,
+            help="The resource to ssh to",
+        )
+        parser.add_argument('args', nargs=argparse.REMAINDER)
+
+    def execute(self, box, args):
+        boxes = self.collect_as_dict("scp")
+        if box not in boxes:
+            raise errors.Error("No such host '{}'".format(box))
+        boxes[box].execute(args)
+
+register(Scp)

--- a/touchdown/goals/scp.py
+++ b/touchdown/goals/scp.py
@@ -36,17 +36,30 @@ class Scp(Goal):
     @classmethod
     def setup_argparse(cls, parser):
         parser.add_argument(
-            "box",
-            metavar="BOX",
+            "source",
+            metavar="SOURCE",
             type=str,
-            help="The resource to ssh to",
+            help="What to copy",
         )
-        parser.add_argument('args', nargs=argparse.REMAINDER)
+        parser.add_argument(
+            "destination",
+            metavar="DESTINATION",
+            type=str,
+            help="Where to copy it",
+        )
 
-    def execute(self, box, args):
+    def execute(self, source, destination):
+        for path in (source, destination):
+            if ":" in path:
+                server = path.split(":", 1)[0]
+                break
+        else:
+            raise errors.Error("Either source or destination must contain a target server that touchdown knows about")
+
         boxes = self.collect_as_dict("scp")
-        if box not in boxes:
-            raise errors.Error("No such host '{}'".format(box))
-        boxes[box].execute(args)
+        if server not in boxes:
+            raise errors.Error("No such host '{}'".format(server))
+
+        boxes[server].execute(source, destination)
 
 register(Scp)

--- a/touchdown/goals/ssh.py
+++ b/touchdown/goals/ssh.py
@@ -1,0 +1,38 @@
+# Copyright 2015 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from touchdown.core import errors
+from touchdown.core.goals import Goal, register
+
+
+class Ssh(Goal):
+
+    """ SSH into infrastructure managed by touchdown """
+
+    name = "ssh"
+    mutator = False
+
+    def get_plan_class(self, resource):
+        plan_class = resource.meta.get_plan("ssh")
+        if not plan_class:
+            plan_class = resource.meta.get_plan("null")
+        return plan_class
+
+    def execute(self, box):
+        boxes = self.collect_as_dict("ssh")
+        if box not in boxes:
+            raise errors.Error("No such host '{}'".format(box))
+        boxes[box].execute()
+
+register(Ssh)

--- a/touchdown/goals/ssh.py
+++ b/touchdown/goals/ssh.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
+
 from touchdown.core import errors
 from touchdown.core.goals import Goal, register
 
@@ -39,11 +41,12 @@ class Ssh(Goal):
             type=str,
             help="The resource to ssh to",
         )
+        parser.add_argument('args', nargs=argparse.REMAINDER)
 
-    def execute(self, box):
+    def execute(self, box, args):
         boxes = self.collect_as_dict("ssh")
         if box not in boxes:
             raise errors.Error("No such host '{}'".format(box))
-        boxes[box].execute()
+        boxes[box].execute(args)
 
 register(Ssh)

--- a/touchdown/goals/ssh.py
+++ b/touchdown/goals/ssh.py
@@ -26,8 +26,19 @@ class Ssh(Goal):
     def get_plan_class(self, resource):
         plan_class = resource.meta.get_plan("ssh")
         if not plan_class:
+            plan_class = resource.meta.get_plan("describe")
+        if not plan_class:
             plan_class = resource.meta.get_plan("null")
         return plan_class
+
+    @classmethod
+    def setup_argparse(cls, parser):
+        parser.add_argument(
+            "box",
+            metavar="BOX",
+            type=str,
+            help="The resource to ssh to",
+        )
 
     def execute(self, box):
         boxes = self.collect_as_dict("ssh")

--- a/touchdown/ssh/__init__.py
+++ b/touchdown/ssh/__init__.py
@@ -15,6 +15,9 @@
 from .client import Client, private_key_from_string
 from .connection import Connection, Instance
 
+from . import terminal  # noqa
+
+
 __all__ = [
     "Client",
     "Connection",

--- a/touchdown/ssh/agent.py
+++ b/touchdown/ssh/agent.py
@@ -1,0 +1,98 @@
+import struct
+import os
+import SocketServer
+import threading
+
+import paramiko
+from paramiko.message import Message
+from paramiko.common import asbytes
+from paramiko.py3compat import byte_chr
+
+
+SSH_AGENT_FAILURE = 5
+SSH_AGENT_SUCCESS = 6
+SSH2_AGENT_IDENTITIES_ANSWER = 12
+SSH2_AGENT_SIGN_RESPONSE = 14
+
+
+class ConnectionError(Exception):
+    pass
+
+
+class AgentRequestHandler(SocketServer.BaseRequestHandler):
+
+    def _read(self, wanted):
+        result = ''
+        while len(result) < wanted:
+            buf = self.request.recv(wanted - len(result))
+            if not buf:
+                raise ConnectionError()
+            result += buf
+        return result
+
+    def read_message(self):
+        size = struct.unpack('>I', self._read(4))[0]
+        msg = Message(self._read(size))
+        return ord(msg.get_byte()), msg
+
+    def send_message(self, msg):
+        msg = asbytes(msg)
+        self.request.sendall(struct.pack('>I', len(msg)) + msg)
+
+    def handler_11(self, msg):
+        # SSH2_AGENTC_REQUEST_IDENTITIES = 11
+        m = Message()
+        m.add_byte(byte_chr(SSH2_AGENT_IDENTITIES_ANSWER))
+        m.add_int(len(self.server.identities))
+        for pkey, comment in self.server.identities.values():
+            m.add_string(pkey.asbytes())
+            m.add_string(comment)
+        return m
+
+    def handler_13(self, msg):
+        # SSH2_AGENTC_SIGN_REQUEST = 13
+        pkey, comment = self.server.identities.get(msg.get_binary(), (None, None))
+        data = msg.get_binary()
+        msg.get_int()
+        m = Message()
+        if not pkey:
+            m.add_byte(chr(SSH_AGENT_FAILURE))
+            return m
+        m.add_byte(chr(SSH2_AGENT_SIGN_RESPONSE))
+        m.add_string(pkey.sign_ssh_data(data).asbytes())
+        return m
+
+    def handle(self):
+        while True:
+            try:
+                mtype, msg = self.read_message()
+            except ConnectionError:
+                return
+
+            handler = getattr(self, "handler_{}".format(mtype))
+            if not handler:
+                print "{!r} not a supported message type".format(mtype)
+                continue
+
+            self.send_message(handler(msg))
+
+
+class AgentServer(SocketServer.UnixStreamServer):
+
+    def __init__(self, socket_file):
+        SocketServer.UnixStreamServer.__init__(self, socket_file, AgentRequestHandler)
+        self.identities = {}
+
+    def add(self, pkey, comment):
+        self.identities[pkey.asbytes()] = (pkey, comment)
+
+    def serve_while_pid(self, pid):
+        t = threading.Thread(target=self.serve_forever)
+        t.daemon = True
+        t.start()
+
+        while os.waitpid(pid, 0)[0] != pid:
+            pass
+
+        self.shutdown()
+        self.server_close()

--- a/touchdown/ssh/agent.py
+++ b/touchdown/ssh/agent.py
@@ -3,7 +3,6 @@ import os
 import SocketServer
 import threading
 
-import paramiko
 from paramiko.message import Message
 from paramiko.common import asbytes
 from paramiko.py3compat import byte_chr
@@ -71,7 +70,6 @@ class AgentRequestHandler(SocketServer.BaseRequestHandler):
 
             handler = getattr(self, "handler_{}".format(mtype))
             if not handler:
-                print "{!r} not a supported message type".format(mtype)
                 continue
 
             self.send_message(handler(msg))

--- a/touchdown/ssh/agent.py
+++ b/touchdown/ssh/agent.py
@@ -8,6 +8,10 @@ from paramiko.common import asbytes
 from paramiko.py3compat import byte_chr
 
 
+if not hasattr(socketserver, "UnixStreamServer"):
+    raise ImportError(__name__)
+
+
 SSH_AGENT_FAILURE = 5
 SSH_AGENT_SUCCESS = 6
 SSH2_AGENT_IDENTITIES_ANSWER = 12

--- a/touchdown/ssh/agent.py
+++ b/touchdown/ssh/agent.py
@@ -1,6 +1,6 @@
 import struct
 import os
-import SocketServer
+from six.moves import socketserver
 import threading
 
 from paramiko.message import Message
@@ -18,7 +18,7 @@ class ConnectionError(Exception):
     pass
 
 
-class AgentRequestHandler(SocketServer.BaseRequestHandler):
+class AgentRequestHandler(socketserver.BaseRequestHandler):
 
     def _read(self, wanted):
         result = ''
@@ -75,10 +75,10 @@ class AgentRequestHandler(SocketServer.BaseRequestHandler):
             self.send_message(handler(msg))
 
 
-class AgentServer(SocketServer.UnixStreamServer):
+class AgentServer(socketserver.UnixStreamServer):
 
     def __init__(self, socket_file):
-        SocketServer.UnixStreamServer.__init__(self, socket_file, AgentRequestHandler)
+        socketserver.UnixStreamServer.__init__(self, socket_file, AgentRequestHandler)
         self.identities = {}
 
     def add(self, pkey, comment):

--- a/touchdown/ssh/connection.py
+++ b/touchdown/ssh/connection.py
@@ -33,6 +33,7 @@ class Connection(Target):
 
     resource_name = "ssh_connection"
 
+    name = argument.String()
     username = argument.String(default="root", field="username")
     password = argument.String(field="password")
     private_key = argument.String(field="pkey", serializer=serializers.Identity())

--- a/touchdown/ssh/terminal.py
+++ b/touchdown/ssh/terminal.py
@@ -36,13 +36,14 @@ class ConnectionPlan(plan.Plan):
         cmd = 'ssh -l {username} -W %h:%p {hostname} {port}'.format(**kwargs)
         return ['-o', 'ProxyCommand={}'.format(cmd)]
 
-    def execute(self):
+    def execute(self, args):
         kwargs = serializers.Resource().render(self.runner, self.resource)
         cmd = ['ssh', '-l', kwargs['username']]
         if self.resource.proxy:
             proxy = self.runner.get_plan(self.resource.proxy)
             cmd.extend(proxy.get_proxy_command())
         cmd.extend(["-p", str(kwargs['port']), kwargs['hostname']])
+        cmd.extend(args)
 
         socket_dir = tempfile.mkdtemp(prefix='ssh-')
         socket_file = os.path.join(socket_dir, 'agent.{}'.format(os.getpid()))

--- a/touchdown/ssh/terminal.py
+++ b/touchdown/ssh/terminal.py
@@ -1,0 +1,67 @@
+# Copyright 2015 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+import time
+
+from touchdown.core import adapters, argument, errors, plan, serializers, workspace
+from .agent import AgentServer
+
+
+class ConnectionPlan(plan.Plan):
+
+    name = "ssh"
+    resource = Connection
+
+    def get_proxy_command(self):
+        kwargs = serializers.Resource().render(self.runner, self.resource)
+        cmd = 'ssh -A -l {username} -W %h:%p {hostname} {port}'.format(kwargs)
+        return ['-o', 'ProxyCommand={}'.format(cmd)]
+
+    @classmethod
+    def setup_argparse(cls, parser):
+        parser.add_argument(
+            "box",
+            metavar="BOX",
+            type=str,
+            help="The resource to ssh to",
+        )
+
+    def execute(self):
+        cmd = ['ssh', '-A', '-l', self.resource.username]
+        if self.resource.proxy:
+            proxy = self.runner.get_plan(self.resource.proxy)
+            cmd.extend(proxy.get_proxy_command())
+        cmd.extend([self.resource.hostname, self.resource.port])
+        print cmd
+
+        socket_dir = tempfile.mkdtemp(prefix='ssh-')
+        socket_file = os.path.join(socket_dir, 'agent.{}'.format(os.getpid()))
+
+        child_pid = os.fork()
+        if child_pid:
+            a = AgentServer(socket_file)
+            a.add(self.resource.private_key, "touchdown.pem")
+            try:
+                a.serve_while_pid(child_pid)
+            finally:
+                shutil.rmtree(socket_dir)
+            return
+
+        while not os.path.exists(socket_file):
+            time.sleep(0.5)
+
+        os.execvpe("/usr/bin/ssh", cmd, {"SSH_AUTH_SOCK": socket_file})

--- a/touchdown/ssh/terminal.py
+++ b/touchdown/ssh/terminal.py
@@ -52,8 +52,8 @@ class SshMixin(object):
             cmd.extend(proxy.get_proxy_command())
         return cmd
 
-    def execute(self, args):
-        cmd = self.get_command()
+    def run(self, args):
+        cmd = self.get_command_and_args()
         cmd.extend(args)
 
         socket_dir = tempfile.mkdtemp(prefix='ssh-')
@@ -93,6 +93,9 @@ class SshPlan(plan.Plan, SshMixin):
         cmd.append("remote")
         return cmd
 
+    def execute(self, args):
+        self.run(args)
+
 
 class ScpPlan(plan.Plan, SshMixin):
 
@@ -101,3 +104,6 @@ class ScpPlan(plan.Plan, SshMixin):
 
     def get_command(self):
         return '/usr/bin/scp'
+
+    def execute(self, source, destination):
+        self.run([source, destination])


### PR DESCRIPTION
If your servers are deployed to by ``touchdown apply`` you might well have setup SSH keys so that touchdown can retrieve and decrypt them. As this is entirely in-process your keys are never decrypted to disk. So it's quite annoying when you have to decrypt them to use SSH - there is no straightforward way to pass an SSH key in memory to the stock SSH client.

This PR aims to authenticate an SSH session using the same keys as used by ``touchdown apply``.

There is a paramiko implementation of a terminal client, but it is glitchy with commands that are interactive like ``top`` or ``vim``

One option is to use ``ssh-agent`` and ``ssh-add``. You'd use paramiko to emulate what ``ssh-add`` does and inject the keys touchdown has access to. This is slightly tricky to orchestrate, and it's about as much work to implement a minimal ``ssh-agent`` - all it has to do is is support listing the registered keys and signing a request from the ssh client - and the code to do that signing is already implemented in paramiko.

With this PIR, if you have defined an SSH connection resource:

    workspace.add_ssh_connection(
        name='servername',
        hostname='127.0.0.1',
        username='ubuntu',
        private_key='dfdfsdfsdf',
    )

Then you can now do:

    touchdown ssh servername
    touchdown scp servername:foo.txt foo.txt
    touchdown scp foo.txt servername:foo.txt

(This also works where you point the ssh_connection resource at something like an autoscaling group).

Under the hood touchdown will fork a child and execvp an ssh client. That child has ``SSH_AUTH_SOCK`` set to a unix socket that it is running from the parent. It can process just 2 SSH agent messages - ``SSH2_AGENTC_REQUEST_IDENTITIES`` and ``SSH2_AGENTC_SIGN_REQUEST``. It will terminate itself after the child process exits.