### PR TITLE
Progressbar2 3.x does not have the `.finished` attribute so is not supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'netaddr',
         'fuselage>=0.0.10',
         'botocore>=1.0.0a2',
-        'progressbar2',
+        'progressbar2<3.0.0',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Specify that we require < 3.0 in the setup file.