### PR TITLE
Support 'update by replacement' for IAM Server Certificates.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,10 @@ Changelog for Touchdown
 0.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support 'update by replacement' for IAM Server Certificates.
+
+- Validates that an IAM Server Certificate `private_key` belongs to its
+  `certificate_body`.
 
 
 0.6.1 (2016-01-27)

--- a/touchdown/aws/cloudfront/distribution.py
+++ b/touchdown/aws/cloudfront/distribution.py
@@ -259,17 +259,21 @@ class Describe(SimpleDescribe, Plan):
     def describe_object_matches(self, d):
         return self.resource.name == d['Comment'] or self.resource.name in d['Aliases'].get('Items', [])
 
+    def annotate_object(self, obj):
+        result = self.client.get_distribution(Id=obj['Id'])
+        distribution = {
+            "ETag": result["ETag"],
+            "Id": obj["Id"],
+            "DomainName": result["Distribution"]["DomainName"],
+            "Status": result["Distribution"]["Status"],
+        }
+        distribution.update(result['Distribution']['DistributionConfig'])
+        return distribution
+
     def describe_object(self):
         distribution = super(Describe, self).describe_object()
         if distribution:
-            result = self.client.get_distribution(Id=distribution['Id'])
-            distribution = {
-                "ETag": result["ETag"],
-                "Id": distribution["Id"],
-                "DomainName": result["Distribution"]["DomainName"],
-                "Status": result["Distribution"]["Status"],
-            }
-            distribution.update(result['Distribution']['DistributionConfig'])
+            distribution = self.annotate_object(distribution)
         return distribution
 
 

--- a/touchdown/aws/cloudtrail/trail.py
+++ b/touchdown/aws/cloudtrail/trail.py
@@ -46,7 +46,7 @@ class Describe(SimpleDescribe, Plan):
     service_name = 'cloudtrail'
     describe_action = "describe_trails"
     describe_envelope = "trailList"
-    key = 'Trail'
+    key = 'Name'
 
     def get_describe_filters(self):
         return {

--- a/touchdown/aws/cloudwatch/alarm.py
+++ b/touchdown/aws/cloudwatch/alarm.py
@@ -102,7 +102,7 @@ class Describe(SimpleDescribe, Plan):
     service_name = 'cloudwatch'
     describe_action = "describe_alarms"
     describe_envelope = "MetricAlarms"
-    key = 'MetricAlarm'
+    key = 'AlarmName'
 
     def get_describe_filters(self):
         return {

--- a/touchdown/aws/replacement.py
+++ b/touchdown/aws/replacement.py
@@ -1,0 +1,103 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from touchdown.core import serializers
+
+from .common import SimpleDescribe, SimpleApply, SimpleDestroy
+
+
+class ReplacementDescribe(SimpleDescribe):
+
+    name = "describe"
+    biggest_serial = 0
+
+    def name_for_remote(self, obj):
+        return obj[self.key]
+
+    def is_possible_object(self, obj):
+        name = self.name_for_remote(obj)
+        if name == self.resource.name:
+            return True
+        if name.startswith(self.resource.name + "."):
+            return True
+
+    def get_possible_objects(self):
+        for obj in super(ReplacementDescribe, self).get_possible_objects():
+            if self.is_possible_object(obj):
+                yield obj
+
+    def describe_object_matches(self, obj):
+        try:
+            serial = self.name_for_remote(obj).rsplit(".", 1)[1]
+            self.biggest_serial = max(int(serial), self.biggest_serial)
+        except (IndexError, TypeError, ValueError):
+            pass
+
+        return self.resource.diff(self.runner, obj).matches()
+
+
+class ReplacementApply(SimpleApply):
+
+    name = "apply"
+
+    def get_create_name(self):
+        return "{}.{}".format(
+            self.resource.name,
+            self.biggest_serial + 1,
+        )
+
+    def get_create_serializer(self):
+        return serializers.Resource(**{
+            self.key: self.get_create_name(),
+        })
+
+    def is_stale(self, obj):
+        # Don't try and delete self!!!
+        if obj[self.key] == self.resource_id:
+            return False
+        return True
+
+    def prepare_to_create(self):
+        """
+        Find all versions of the named resource and if they are stale terminate them
+
+        What it means to be stale varies between resources so this is delegated to `self.is_stale`.
+        """
+        # TODO: There is a considerable amount of overlap with the destroy action here...
+        for obj in self.get_possible_objects():
+            if not self.is_stale(obj):
+                continue
+
+            yield self.generic_action(
+                "Destroy stale {} {}".format(self.resource.resource_name, obj[self.key]),
+                getattr(self.client, self.destroy_action),
+                serializers.Dict(**{self.key: obj[self.key]}),
+            )
+
+
+class ReplacementDestroy(SimpleDestroy):
+
+    name = "destroy"
+
+    def get_destroy_serializer(self, resource_id):
+        return serializers.Dict(**{self.key: resource_id})
+
+    def get_actions(self):
+        self.object = self.describe_object()
+        for obj in self.get_possible_objects():
+            yield self.generic_action(
+                "Destroy {} {}".format(self.resource.resource_name, obj[self.key]),
+                getattr(self.client, self.destroy_action),
+                self.get_destroy_serializer(obj[self.key]),
+            )

--- a/touchdown/aws/vpc/customer_gateway.py
+++ b/touchdown/aws/vpc/customer_gateway.py
@@ -45,13 +45,6 @@ class Describe(SimpleDescribe, Plan):
         if not vpc.resource_id:
             return None
 
-        if self.key in self.object:
-            return {
-                "Filters": [
-                    {'Name': 'customer-gateway-id', 'Values': [self.object[self.key]]}
-                ]
-            }
-
         return {
             "Filters": [
                 {'Name': 'tag:Name', 'Values': [self.resource.name]},

--- a/touchdown/aws/vpc/internet_gateway.py
+++ b/touchdown/aws/vpc/internet_gateway.py
@@ -42,13 +42,6 @@ class Describe(SimpleDescribe, Plan):
         if not vpc.resource_id:
             return None
 
-        if self.key in self.object:
-            return {
-                "Filters": [
-                    {'Name': 'internet-gateway-id', 'Values': [self.object[self.key]]}
-                ]
-            }
-
         return {
             "Filters": [
                 {'Name': 'tag:Name', 'Values': [self.resource.name]},

--- a/touchdown/aws/vpc/route_table.py
+++ b/touchdown/aws/vpc/route_table.py
@@ -64,13 +64,6 @@ class Describe(SimpleDescribe, Plan):
         if not vpc.resource_id:
             return None
 
-        if self.key in self.object:
-            return {
-                "Filters": [
-                    {'Name': 'route-table-id', 'Values': [self.object[self.key]]}
-                ]
-            }
-
         return {
             "Filters": [
                 {'Name': 'tag:Name', 'Values': [self.resource.name]},

--- a/touchdown/aws/vpc/security_group.py
+++ b/touchdown/aws/vpc/security_group.py
@@ -125,13 +125,6 @@ class Describe(SimpleDescribe, Plan):
         if not vpc.resource_id:
             return None
 
-        if self.key in self.object:
-            return {
-                "Filters": [
-                    {'Name': 'group-id', 'Values': [self.object[self.key]]}
-                ]
-            }
-
         vpc = self.runner.get_plan(self.resource.vpc)
         return {
             "Filters": [

--- a/touchdown/aws/vpc/vpc.py
+++ b/touchdown/aws/vpc/vpc.py
@@ -42,13 +42,6 @@ class Describe(SimpleDescribe, Plan):
     key = 'VpcId'
 
     def get_describe_filters(self):
-        if self.key in self.object:
-            return {
-                "Filters": [
-                    {'Name': 'vpc-id', 'Values': [self.object[self.key]]}
-                ]
-            }
-
         return {
             "Filters": [
                 {'Name': 'tag:Name', 'Values': [self.resource.name]},

--- a/touchdown/aws/vpc/vpn_connection.py
+++ b/touchdown/aws/vpc/vpn_connection.py
@@ -57,13 +57,6 @@ class Describe(SimpleDescribe, Plan):
         if not vpc.resource_id:
             return None
 
-        if self.key in self.object:
-            return {
-                "Filters": [
-                    {'Name': 'vpn-connection-id', 'Values': [self.object[self.key]]}
-                ]
-            }
-
         return {
             "Filters": [
                 {'Name': 'tag:Name', 'Values': [self.resource.name]},

--- a/touchdown/aws/vpc/vpn_gateway.py
+++ b/touchdown/aws/vpc/vpn_gateway.py
@@ -75,13 +75,6 @@ class Describe(SimpleDescribe, Plan):
         if not vpc.resource_id:
             return None
 
-        if self.key in self.object:
-            return {
-                "Filters": [
-                    {'Name': 'vpn-gateway-id', 'Values': [self.object[self.key]]}
-                ]
-            }
-
         return {
             "Filters": [
                 {'Name': 'tag:Name', 'Values': [self.resource.name]},

--- a/touchdown/core/resource.py
+++ b/touchdown/core/resource.py
@@ -221,6 +221,13 @@ class Resource(six.with_metaclass(ResourceType)):
             serializers.Resource(**kwargs),
         )
 
+    def diff(self, runner, value, **kwargs):
+        return serializers.Resource(**kwargs).diff(
+            runner,
+            self,
+            value
+        )
+
     @property
     def arguments(self):
         return list((name, field.argument) for (name, field) in self.meta.iter_fields_in_order())

--- a/touchdown/core/serializers.py
+++ b/touchdown/core/serializers.py
@@ -134,7 +134,7 @@ class Identifier(Serializer):
         d = Resource().diff(
             runner,
             resource,
-            describe.lookup_version(value),
+            describe.get_object_by_id(value),
         )
         d.diffs.insert(0, ("name", diff.ValueDiff(value, rendered)))
         return d

--- a/touchdown/tests/cassettes/touchdown.tests.test_aws_ec2_launch_configuration.TestRole.test_create_and_delete_role.yml
+++ b/touchdown/tests/cassettes/touchdown.tests.test_aws_ec2_launch_configuration.TestRole.test_create_and_delete_role.yml
@@ -1,252 +1,307 @@
 interactions:
 - request:
-    body: Action=DescribeLaunchConfigurations&Version=2011-01-01
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170105Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DescribeLaunchConfigurationsResponse xmlns=\"\
-        http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <DescribeLaunchConfigurationsResult>\n\
-        \    <LaunchConfigurations/>\n  </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n\
-        \    <RequestId>52c5c98e-ee91-11e4-aa63-db002c419931</RequestId>\n  </ResponseMetadata>\n\
-        </DescribeLaunchConfigurationsResponse>\n"}
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations/>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>60cefa9e-c80f-11e5-9496-5d4558cc0daf</RequestId>\n\
+        \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
     headers:
-      content-length: ['350']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:05 GMT']
-      x-amzn-requestid: [52c5c98e-ee91-11e4-aa63-db002c419931]
+      Content-Length: ['350']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:07 GMT']
+      x-amzn-RequestId: [60cefa9e-c80f-11e5-9496-5d4558cc0daf]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeLaunchConfigurations&Version=2011-01-01
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170105Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DescribeLaunchConfigurationsResponse xmlns=\"\
-        http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <DescribeLaunchConfigurationsResult>\n\
-        \    <LaunchConfigurations/>\n  </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n\
-        \    <RequestId>52e02f54-ee91-11e4-89b0-0d74b52ccee9</RequestId>\n  </ResponseMetadata>\n\
-        </DescribeLaunchConfigurationsResponse>\n"}
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations/>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>60ebf8cc-c80f-11e5-9f10-b1f3d613c73d</RequestId>\n\
+        \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
     headers:
-      content-length: ['350']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:04 GMT']
-      x-amzn-requestid: [52e02f54-ee91-11e4-89b0-0d74b52ccee9]
+      Content-Length: ['350']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:07 GMT']
+      x-amzn-RequestId: [60ebf8cc-c80f-11e5-9f10-b1f3d613c73d]
     status: {code: 200, message: OK}
 - request:
-    body: InstanceMonitoring.Enabled=false&ImageId=ami-cba130bc&Version=2011-01-01&LaunchConfigurationName=my-test-lc.1&Action=CreateLaunchConfiguration&InstanceType=t2.micro
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkxhdW5jaENvbmZpZ3VyYXRpb25OYW1lPW15LXRlc3QtbGMuMSZB
+      Y3Rpb249Q3JlYXRlTGF1bmNoQ29uZmlndXJhdGlvbiZJbWFnZUlkPWFtaS1jYmExMzBiYyZJbnN0
+      YW5jZVR5cGU9dDIubWljcm8mSW5zdGFuY2VNb25pdG9yaW5nLkVuYWJsZWQ9ZmFsc2U=
     headers:
       Content-Length: ['164']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170105Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<CreateLaunchConfigurationResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
-        >\n  <ResponseMetadata>\n    <RequestId>52f9ab21-ee91-11e4-b27e-73d84c3ba62a</RequestId>\n\
+    body: {string: "<CreateLaunchConfigurationResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <ResponseMetadata>\n    <RequestId>60fd3698-c80f-11e5-8b91-4d4736b0ad5d</RequestId>\n\
         \  </ResponseMetadata>\n</CreateLaunchConfigurationResponse>\n"}
     headers:
-      content-length: ['237']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:05 GMT']
-      x-amzn-requestid: [52f9ab21-ee91-11e4-b27e-73d84c3ba62a]
+      Content-Length: ['237']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:07 GMT']
+      x-amzn-RequestId: [60fd3698-c80f-11e5-8b91-4d4736b0ad5d]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeLaunchConfigurations&Version=2011-01-01
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170105Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DescribeLaunchConfigurationsResponse xmlns=\"\
-        http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <DescribeLaunchConfigurationsResult>\n\
-        \    <LaunchConfigurations>\n      <member>\n        <SecurityGroups/>\n \
-        \       <CreatedTime>2015-04-29T17:01:05.932Z</CreatedTime>\n        <KernelId/>\n\
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations>\n  \
+        \    <member>\n        <KernelId/>\n        <RamdiskId/>\n        <EbsOptimized>false</EbsOptimized>\n\
+        \        <UserData/>\n        <ImageId>ami-cba130bc</ImageId>\n        <BlockDeviceMappings/>\n\
+        \        <ClassicLinkVPCSecurityGroups/>\n        <InstanceType>t2.micro</InstanceType>\n\
+        \        <KeyName/>\n        <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:x0x0x0x0x0x0:launchConfiguration:01d052e1-a2e2-452e-a946-99cc28acc273:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
         \        <LaunchConfigurationName>my-test-lc.1</LaunchConfigurationName>\n\
-        \        <UserData/>\n        <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:000000000000:launchConfiguration:0d557f21-0eb8-4411-ad49-69b0a023e883:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
-        \        <InstanceType>t2.micro</InstanceType>\n        <BlockDeviceMappings/>\n\
-        \        <ImageId>ami-cba130bc</ImageId>\n        <KeyName/>\n        <RamdiskId/>\n\
+        \        <CreatedTime>2016-01-31T11:40:08.335Z</CreatedTime>\n        <SecurityGroups/>\n\
         \        <InstanceMonitoring>\n          <Enabled>false</Enabled>\n      \
-        \  </InstanceMonitoring>\n        <ClassicLinkVPCSecurityGroups/>\n      \
-        \  <EbsOptimized>false</EbsOptimized>\n      </member>\n    </LaunchConfigurations>\n\
-        \  </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>532a5891-ee91-11e4-8fd3-4f243a31cf27</RequestId>\n\
+        \  </InstanceMonitoring>\n      </member>\n    </LaunchConfigurations>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>6129289a-c80f-11e5-9496-5d4558cc0daf</RequestId>\n\
         \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
     headers:
-      content-length: ['1134']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:05 GMT']
-      x-amzn-requestid: [532a5891-ee91-11e4-8fd3-4f243a31cf27]
+      Content-Length: ['1134']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:08 GMT']
+      x-amzn-RequestId: [6129289a-c80f-11e5-9496-5d4558cc0daf]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeLaunchConfigurations&Version=2011-01-01
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170106Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DescribeLaunchConfigurationsResponse xmlns=\"\
-        http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <DescribeLaunchConfigurationsResult>\n\
-        \    <LaunchConfigurations>\n      <member>\n        <SecurityGroups/>\n \
-        \       <CreatedTime>2015-04-29T17:01:05.932Z</CreatedTime>\n        <KernelId/>\n\
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations>\n  \
+        \    <member>\n        <KernelId/>\n        <RamdiskId/>\n        <EbsOptimized>false</EbsOptimized>\n\
+        \        <UserData/>\n        <ImageId>ami-cba130bc</ImageId>\n        <BlockDeviceMappings/>\n\
+        \        <ClassicLinkVPCSecurityGroups/>\n        <InstanceType>t2.micro</InstanceType>\n\
+        \        <KeyName/>\n        <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:x0x0x0x0x0x0:launchConfiguration:01d052e1-a2e2-452e-a946-99cc28acc273:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
         \        <LaunchConfigurationName>my-test-lc.1</LaunchConfigurationName>\n\
-        \        <UserData/>\n        <InstanceType>t2.micro</InstanceType>\n    \
-        \    <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:000000000000:launchConfiguration:0d557f21-0eb8-4411-ad49-69b0a023e883:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
-        \        <BlockDeviceMappings/>\n        <ImageId>ami-cba130bc</ImageId>\n\
-        \        <KeyName/>\n        <RamdiskId/>\n        <InstanceMonitoring>\n\
-        \          <Enabled>false</Enabled>\n        </InstanceMonitoring>\n     \
-        \   <ClassicLinkVPCSecurityGroups/>\n        <EbsOptimized>false</EbsOptimized>\n\
-        \      </member>\n    </LaunchConfigurations>\n  </DescribeLaunchConfigurationsResult>\n\
-        \  <ResponseMetadata>\n    <RequestId>53464494-ee91-11e4-8a09-778d805d2d25</RequestId>\n\
+        \        <CreatedTime>2016-01-31T11:40:08.335Z</CreatedTime>\n        <SecurityGroups/>\n\
+        \        <InstanceMonitoring>\n          <Enabled>false</Enabled>\n      \
+        \  </InstanceMonitoring>\n      </member>\n    </LaunchConfigurations>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>61427d75-c80f-11e5-a89b-53a41bfc3229</RequestId>\n\
         \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
     headers:
-      content-length: ['1134']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:05 GMT']
-      x-amzn-requestid: [53464494-ee91-11e4-8a09-778d805d2d25]
+      Content-Length: ['1134']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:08 GMT']
+      x-amzn-RequestId: [61427d75-c80f-11e5-a89b-53a41bfc3229]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeLaunchConfigurations&Version=2011-01-01
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170106Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DescribeLaunchConfigurationsResponse xmlns=\"\
-        http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <DescribeLaunchConfigurationsResult>\n\
-        \    <LaunchConfigurations>\n      <member>\n        <SecurityGroups/>\n \
-        \       <CreatedTime>2015-04-29T17:01:05.932Z</CreatedTime>\n        <KernelId/>\n\
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations>\n  \
+        \    <member>\n        <KernelId/>\n        <RamdiskId/>\n        <EbsOptimized>false</EbsOptimized>\n\
+        \        <UserData/>\n        <ImageId>ami-cba130bc</ImageId>\n        <BlockDeviceMappings/>\n\
+        \        <ClassicLinkVPCSecurityGroups/>\n        <InstanceType>t2.micro</InstanceType>\n\
+        \        <KeyName/>\n        <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:x0x0x0x0x0x0:launchConfiguration:01d052e1-a2e2-452e-a946-99cc28acc273:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
         \        <LaunchConfigurationName>my-test-lc.1</LaunchConfigurationName>\n\
-        \        <UserData/>\n        <InstanceType>t2.micro</InstanceType>\n    \
-        \    <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:000000000000:launchConfiguration:0d557f21-0eb8-4411-ad49-69b0a023e883:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
-        \        <BlockDeviceMappings/>\n        <ImageId>ami-cba130bc</ImageId>\n\
-        \        <KeyName/>\n        <RamdiskId/>\n        <InstanceMonitoring>\n\
-        \          <Enabled>false</Enabled>\n        </InstanceMonitoring>\n     \
-        \   <ClassicLinkVPCSecurityGroups/>\n        <EbsOptimized>false</EbsOptimized>\n\
-        \      </member>\n    </LaunchConfigurations>\n  </DescribeLaunchConfigurationsResult>\n\
-        \  <ResponseMetadata>\n    <RequestId>535fc040-ee91-11e4-b08a-bd487c9dc8f7</RequestId>\n\
+        \        <CreatedTime>2016-01-31T11:40:08.335Z</CreatedTime>\n        <SecurityGroups/>\n\
+        \        <InstanceMonitoring>\n          <Enabled>false</Enabled>\n      \
+        \  </InstanceMonitoring>\n      </member>\n    </LaunchConfigurations>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>615ae776-c80f-11e5-a89b-53a41bfc3229</RequestId>\n\
         \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
     headers:
-      content-length: ['1134']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:06 GMT']
-      x-amzn-requestid: [535fc040-ee91-11e4-b08a-bd487c9dc8f7]
+      Content-Length: ['1134']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:08 GMT']
+      x-amzn-RequestId: [615ae776-c80f-11e5-a89b-53a41bfc3229]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeLaunchConfigurations&Version=2011-01-01
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170106Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DescribeLaunchConfigurationsResponse xmlns=\"\
-        http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <DescribeLaunchConfigurationsResult>\n\
-        \    <LaunchConfigurations>\n      <member>\n        <SecurityGroups/>\n \
-        \       <CreatedTime>2015-04-29T17:01:05.932Z</CreatedTime>\n        <KernelId/>\n\
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations>\n  \
+        \    <member>\n        <KernelId/>\n        <EbsOptimized>false</EbsOptimized>\n\
+        \        <RamdiskId/>\n        <UserData/>\n        <ImageId>ami-cba130bc</ImageId>\n\
+        \        <BlockDeviceMappings/>\n        <ClassicLinkVPCSecurityGroups/>\n\
+        \        <InstanceType>t2.micro</InstanceType>\n        <KeyName/>\n     \
+        \   <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:x0x0x0x0x0x0:launchConfiguration:01d052e1-a2e2-452e-a946-99cc28acc273:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
         \        <LaunchConfigurationName>my-test-lc.1</LaunchConfigurationName>\n\
-        \        <UserData/>\n        <InstanceType>t2.micro</InstanceType>\n    \
-        \    <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:000000000000:launchConfiguration:0d557f21-0eb8-4411-ad49-69b0a023e883:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
-        \        <BlockDeviceMappings/>\n        <ImageId>ami-cba130bc</ImageId>\n\
-        \        <KeyName/>\n        <RamdiskId/>\n        <InstanceMonitoring>\n\
-        \          <Enabled>false</Enabled>\n        </InstanceMonitoring>\n     \
-        \   <ClassicLinkVPCSecurityGroups/>\n        <EbsOptimized>false</EbsOptimized>\n\
-        \      </member>\n    </LaunchConfigurations>\n  </DescribeLaunchConfigurationsResult>\n\
-        \  <ResponseMetadata>\n    <RequestId>537e924d-ee91-11e4-aa63-db002c419931</RequestId>\n\
+        \        <CreatedTime>2016-01-31T11:40:08.335Z</CreatedTime>\n        <SecurityGroups/>\n\
+        \        <InstanceMonitoring>\n          <Enabled>false</Enabled>\n      \
+        \  </InstanceMonitoring>\n      </member>\n    </LaunchConfigurations>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>6170b88d-c80f-11e5-866d-8332485f3d7e</RequestId>\n\
         \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
     headers:
-      content-length: ['1134']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:06 GMT']
-      x-amzn-requestid: [537e924d-ee91-11e4-aa63-db002c419931]
+      Content-Length: ['1134']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:08 GMT']
+      x-amzn-RequestId: [6170b88d-c80f-11e5-866d-8332485f3d7e]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeLaunchConfigurations&Version=2011-01-01
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170106Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DescribeLaunchConfigurationsResponse xmlns=\"\
-        http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <DescribeLaunchConfigurationsResult>\n\
-        \    <LaunchConfigurations>\n      <member>\n        <SecurityGroups/>\n \
-        \       <CreatedTime>2015-04-29T17:01:05.932Z</CreatedTime>\n        <KernelId/>\n\
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations>\n  \
+        \    <member>\n        <KernelId/>\n        <RamdiskId/>\n        <EbsOptimized>false</EbsOptimized>\n\
+        \        <UserData/>\n        <ImageId>ami-cba130bc</ImageId>\n        <BlockDeviceMappings/>\n\
+        \        <ClassicLinkVPCSecurityGroups/>\n        <InstanceType>t2.micro</InstanceType>\n\
+        \        <KeyName/>\n        <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:x0x0x0x0x0x0:launchConfiguration:01d052e1-a2e2-452e-a946-99cc28acc273:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
         \        <LaunchConfigurationName>my-test-lc.1</LaunchConfigurationName>\n\
-        \        <UserData/>\n        <InstanceType>t2.micro</InstanceType>\n    \
-        \    <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:000000000000:launchConfiguration:0d557f21-0eb8-4411-ad49-69b0a023e883:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
-        \        <BlockDeviceMappings/>\n        <ImageId>ami-cba130bc</ImageId>\n\
-        \        <KeyName/>\n        <RamdiskId/>\n        <InstanceMonitoring>\n\
-        \          <Enabled>false</Enabled>\n        </InstanceMonitoring>\n     \
-        \   <ClassicLinkVPCSecurityGroups/>\n        <EbsOptimized>false</EbsOptimized>\n\
-        \      </member>\n    </LaunchConfigurations>\n  </DescribeLaunchConfigurationsResult>\n\
-        \  <ResponseMetadata>\n    <RequestId>539c7b14-ee91-11e4-84a7-3bea9c27020a</RequestId>\n\
+        \        <CreatedTime>2016-01-31T11:40:08.335Z</CreatedTime>\n        <SecurityGroups/>\n\
+        \        <InstanceMonitoring>\n          <Enabled>false</Enabled>\n      \
+        \  </InstanceMonitoring>\n      </member>\n    </LaunchConfigurations>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>618ca513-c80f-11e5-a523-256ce7a03fbc</RequestId>\n\
         \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
     headers:
-      content-length: ['1134']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:06 GMT']
-      x-amzn-requestid: [539c7b14-ee91-11e4-84a7-3bea9c27020a]
+      Content-Length: ['1134']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:08 GMT']
+      x-amzn-RequestId: [618ca513-c80f-11e5-a523-256ce7a03fbc]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DeleteLaunchConfiguration&Version=2011-01-01&LaunchConfigurationName=my-test-lc.1
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
+    headers:
+      Content-Length: ['54']
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://autoscaling.eu-west-1.amazonaws.com/
+  response:
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations>\n  \
+        \    <member>\n        <KernelId/>\n        <RamdiskId/>\n        <EbsOptimized>false</EbsOptimized>\n\
+        \        <UserData/>\n        <ImageId>ami-cba130bc</ImageId>\n        <BlockDeviceMappings/>\n\
+        \        <ClassicLinkVPCSecurityGroups/>\n        <InstanceType>t2.micro</InstanceType>\n\
+        \        <KeyName/>\n        <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:x0x0x0x0x0x0:launchConfiguration:01d052e1-a2e2-452e-a946-99cc28acc273:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
+        \        <LaunchConfigurationName>my-test-lc.1</LaunchConfigurationName>\n\
+        \        <CreatedTime>2016-01-31T11:40:08.335Z</CreatedTime>\n        <SecurityGroups/>\n\
+        \        <InstanceMonitoring>\n          <Enabled>false</Enabled>\n      \
+        \  </InstanceMonitoring>\n      </member>\n    </LaunchConfigurations>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>61a55d3c-c80f-11e5-9698-bb06e425adda</RequestId>\n\
+        \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
+    headers:
+      Content-Length: ['1134']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:08 GMT']
+      x-amzn-RequestId: [61a55d3c-c80f-11e5-9698-bb06e425adda]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
+    headers:
+      Content-Length: ['54']
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://autoscaling.eu-west-1.amazonaws.com/
+  response:
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations>\n  \
+        \    <member>\n        <KernelId/>\n        <RamdiskId/>\n        <EbsOptimized>false</EbsOptimized>\n\
+        \        <UserData/>\n        <ImageId>ami-cba130bc</ImageId>\n        <BlockDeviceMappings/>\n\
+        \        <ClassicLinkVPCSecurityGroups/>\n        <InstanceType>t2.micro</InstanceType>\n\
+        \        <KeyName/>\n        <LaunchConfigurationARN>arn:aws:autoscaling:eu-west-1:x0x0x0x0x0x0:launchConfiguration:01d052e1-a2e2-452e-a946-99cc28acc273:launchConfigurationName/my-test-lc.1</LaunchConfigurationARN>\n\
+        \        <LaunchConfigurationName>my-test-lc.1</LaunchConfigurationName>\n\
+        \        <CreatedTime>2016-01-31T11:40:08.335Z</CreatedTime>\n        <SecurityGroups/>\n\
+        \        <InstanceMonitoring>\n          <Enabled>false</Enabled>\n      \
+        \  </InstanceMonitoring>\n      </member>\n    </LaunchConfigurations>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>61bd521d-c80f-11e5-87df-752784b2ba99</RequestId>\n\
+        \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
+    headers:
+      Content-Length: ['1134']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:08 GMT']
+      x-amzn-RequestId: [61bd521d-c80f-11e5-87df-752784b2ba99]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkxhdW5jaENvbmZpZ3VyYXRpb25OYW1lPW15LXRlc3QtbGMuMSZB
+      Y3Rpb249RGVsZXRlTGF1bmNoQ29uZmlndXJhdGlvbg==
     headers:
       Content-Length: ['88']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170106Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DeleteLaunchConfigurationResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
-        >\n  <ResponseMetadata>\n    <RequestId>53b6e106-ee91-11e4-acd1-7fa3e8e2c1e6</RequestId>\n\
+    body: {string: "<DeleteLaunchConfigurationResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <ResponseMetadata>\n    <RequestId>61d76a71-c80f-11e5-a5fb-3fc98720f597</RequestId>\n\
         \  </ResponseMetadata>\n</DeleteLaunchConfigurationResponse>\n"}
     headers:
-      content-length: ['237']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:06 GMT']
-      x-amzn-requestid: [53b6e106-ee91-11e4-acd1-7fa3e8e2c1e6]
+      Content-Length: ['237']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:09 GMT']
+      x-amzn-RequestId: [61d76a71-c80f-11e5-a5fb-3fc98720f597]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeLaunchConfigurations&Version=2011-01-01
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.103.0 Python/2.7.6 Linux/3.13.0-43-generic]
-      X-Amz-Date: [20150429T170107Z]
-    method: !!python/unicode 'POST'
+    method: POST
     uri: https://autoscaling.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<DescribeLaunchConfigurationsResponse xmlns=\"\
-        http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <DescribeLaunchConfigurationsResult>\n\
-        \    <LaunchConfigurations/>\n  </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n\
-        \    <RequestId>53d23169-ee91-11e4-9b90-8bc38b953b8c</RequestId>\n  </ResponseMetadata>\n\
-        </DescribeLaunchConfigurationsResponse>\n"}
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations/>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>61ee7490-c80f-11e5-9b4f-83a673820889</RequestId>\n\
+        \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
     headers:
-      content-length: ['350']
-      content-type: [text/xml]
-      date: ['Wed, 29 Apr 2015 17:01:06 GMT']
-      x-amzn-requestid: [53d23169-ee91-11e4-9b90-8bc38b953b8c]
+      Content-Length: ['350']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:08 GMT']
+      x-amzn-RequestId: [61ee7490-c80f-11e5-9b4f-83a673820889]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      VmVyc2lvbj0yMDExLTAxLTAxJkFjdGlvbj1EZXNjcmliZUxhdW5jaENvbmZpZ3VyYXRpb25z
+    headers:
+      Content-Length: ['54']
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://autoscaling.eu-west-1.amazonaws.com/
+  response:
+    body: {string: "<DescribeLaunchConfigurationsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\"\
+        >\n  <DescribeLaunchConfigurationsResult>\n    <LaunchConfigurations/>\n \
+        \ </DescribeLaunchConfigurationsResult>\n  <ResponseMetadata>\n    <RequestId>6203d1a6-c80f-11e5-8813-b32550152208</RequestId>\n\
+        \  </ResponseMetadata>\n</DescribeLaunchConfigurationsResponse>\n"}
+    headers:
+      Content-Length: ['350']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:40:09 GMT']
+      x-amzn-RequestId: [6203d1a6-c80f-11e5-8813-b32550152208]
     status: {code: 200, message: OK}
 version: 1

--- a/touchdown/tests/cassettes/touchdown.tests.test_aws_sqs_queue.TestQueue.test_create_and_delete_queue.yml
+++ b/touchdown/tests/cassettes/touchdown.tests.test_aws_sqs_queue.TestQueue.test_create_and_delete_queue.yml
@@ -1,236 +1,237 @@
 interactions:
 - request:
-    body: Action=GetQueueUrl&Version=2012-11-05&QueueName=test-queue
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlTmFtZT10ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1ZVVy
+      bA==
     headers:
       Content-Length: ['58']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110756Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.NonExistentQueue</Code><Message>The
-        specified queue does not exist for this wsdl version.</Message><Detail/></Error><RequestId>28c462a8-cb81-56b2-b5b0-2fd8224c8646</RequestId></ErrorResponse>'}
+    body: {string: '<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.NonExistentQueue</Code><Message>The
+        specified queue does not exist for this wsdl version.</Message><Detail/></Error><RequestId>eef9114e-8a74-519d-9338-5e697f822228</RequestId></ErrorResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['333']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:57 GMT']
-      server: [Server]
-      x-amzn-requestid: [28c462a8-cb81-56b2-b5b0-2fd8224c8646]
+      Connection: [keep-alive]
+      Content-Length: ['333']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:54 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [eef9114e-8a74-519d-9338-5e697f822228]
     status: {code: 400, message: Bad Request}
 - request:
-    body: Action=CreateQueue&Version=2012-11-05&QueueName=test-queue
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlTmFtZT10ZXN0LXF1ZXVlJkFjdGlvbj1DcmVhdGVRdWV1
+      ZQ==
     headers:
       Content-Length: ['58']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110757Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><CreateQueueResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><CreateQueueResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></CreateQueueResult><ResponseMetadata><RequestId>1c3c77c5-40be-55cf-be58-3ab5a973953b</RequestId></ResponseMetadata></CreateQueueResponse>'}
+    body: {string: '<?xml version="1.0"?><CreateQueueResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><CreateQueueResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></CreateQueueResult><ResponseMetadata><RequestId>f717f1dd-040c-526d-954c-befaf1fa9ef1</RequestId></ResponseMetadata></CreateQueueResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['332']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:57 GMT']
-      server: [Server]
-      x-amzn-requestid: [1c3c77c5-40be-55cf-be58-3ab5a973953b]
+      Connection: [keep-alive]
+      Content-Length: ['332']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:54 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [f717f1dd-040c-526d-954c-befaf1fa9ef1]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueUrl&Version=2012-11-05&QueueName=test-queue
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlTmFtZT10ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1ZVVy
+      bA==
     headers:
       Content-Length: ['58']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110757Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>46ed305d-d5a2-5144-9aac-7d2d3c6f91b0</RequestId></ResponseMetadata></GetQueueUrlResponse>'}
+    body: {string: '<?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>6a39a50d-594c-5bc1-a06d-ea2aacba235f</RequestId></ResponseMetadata></GetQueueUrlResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['332']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:57 GMT']
-      server: [Server]
-      x-amzn-requestid: [46ed305d-d5a2-5144-9aac-7d2d3c6f91b0]
+      Connection: [keep-alive]
+      Content-Length: ['332']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:54 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [6a39a50d-594c-5bc1-a06d-ea2aacba235f]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueAttributes&QueueUrl=https%3A%2F%2Feu-west-1.queue.amazonaws.com%2F000000000000%2Ftest-queue&Version=2012-11-05&AttributeName.1=All
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlVXJsPWh0dHBzJTNBJTJGJTJGZXUtd2VzdC0xLnF1ZXVl
+      LmFtYXpvbmF3cy5jb20lMkY4NTQ2ODk3MTE4MjQlMkZ0ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1
+      ZUF0dHJpYnV0ZXMmQXR0cmlidXRlTmFtZS4xPUFsbA==
     headers:
       Content-Length: ['145']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110757Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><GetQueueAttributesResponse
-        xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:eu-west-1:000000000000:test-queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1425467277</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1425467277</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>ad07866e-17f6-5f6b-ba33-cb1efe3b9f9f</RequestId></ResponseMetadata></GetQueueAttributesResponse>'}
+    body: {string: '<?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:eu-west-1:000000000000:test-queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1454240694</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1454240694</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>be581749-358c-59d2-9a53-586ec07a0269</RequestId></ResponseMetadata></GetQueueAttributesResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['1164']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:57 GMT']
-      server: [Server]
-      x-amzn-requestid: [ad07866e-17f6-5f6b-ba33-cb1efe3b9f9f]
+      Connection: [keep-alive]
+      Content-Length: ['1164']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:54 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [be581749-358c-59d2-9a53-586ec07a0269]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueUrl&Version=2012-11-05&QueueName=test-queue
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlTmFtZT10ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1ZVVy
+      bA==
     headers:
       Content-Length: ['58']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110757Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>e2a5bc86-8a5d-5d17-909d-f1f663902de3</RequestId></ResponseMetadata></GetQueueUrlResponse>'}
+    body: {string: '<?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>8fa6e9fe-097f-5ff3-a458-a6d9fc88d3e2</RequestId></ResponseMetadata></GetQueueUrlResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['332']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:57 GMT']
-      server: [Server]
-      x-amzn-requestid: [e2a5bc86-8a5d-5d17-909d-f1f663902de3]
+      Connection: [keep-alive]
+      Content-Length: ['332']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:55 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [8fa6e9fe-097f-5ff3-a458-a6d9fc88d3e2]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueAttributes&QueueUrl=https%3A%2F%2Feu-west-1.queue.amazonaws.com%2F000000000000%2Ftest-queue&Version=2012-11-05&AttributeName.1=All
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlVXJsPWh0dHBzJTNBJTJGJTJGZXUtd2VzdC0xLnF1ZXVl
+      LmFtYXpvbmF3cy5jb20lMkY4NTQ2ODk3MTE4MjQlMkZ0ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1
+      ZUF0dHJpYnV0ZXMmQXR0cmlidXRlTmFtZS4xPUFsbA==
     headers:
       Content-Length: ['145']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110758Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><GetQueueAttributesResponse
-        xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:eu-west-1:000000000000:test-queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1425467277</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1425467277</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>a21b048b-efb9-5118-81eb-49fb0674d1ec</RequestId></ResponseMetadata></GetQueueAttributesResponse>'}
+    body: {string: '<?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:eu-west-1:000000000000:test-queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1454240694</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1454240694</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>098245a8-1bbb-546f-9cd8-0a8fee4c03fa</RequestId></ResponseMetadata></GetQueueAttributesResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['1164']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:57 GMT']
-      server: [Server]
-      x-amzn-requestid: [a21b048b-efb9-5118-81eb-49fb0674d1ec]
+      Connection: [keep-alive]
+      Content-Length: ['1164']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:55 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [098245a8-1bbb-546f-9cd8-0a8fee4c03fa]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueUrl&Version=2012-11-05&QueueName=test-queue
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlTmFtZT10ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1ZVVy
+      bA==
     headers:
       Content-Length: ['58']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110758Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>8370ac58-87ea-5c10-9425-e1286e24ace4</RequestId></ResponseMetadata></GetQueueUrlResponse>'}
+    body: {string: '<?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>c423daa8-a8f3-5a41-be23-958f5d0464e2</RequestId></ResponseMetadata></GetQueueUrlResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['332']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:58 GMT']
-      server: [Server]
-      x-amzn-requestid: [8370ac58-87ea-5c10-9425-e1286e24ace4]
+      Connection: [keep-alive]
+      Content-Length: ['332']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:55 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [c423daa8-a8f3-5a41-be23-958f5d0464e2]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueAttributes&QueueUrl=https%3A%2F%2Feu-west-1.queue.amazonaws.com%2F000000000000%2Ftest-queue&Version=2012-11-05&AttributeName.1=All
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlVXJsPWh0dHBzJTNBJTJGJTJGZXUtd2VzdC0xLnF1ZXVl
+      LmFtYXpvbmF3cy5jb20lMkY4NTQ2ODk3MTE4MjQlMkZ0ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1
+      ZUF0dHJpYnV0ZXMmQXR0cmlidXRlTmFtZS4xPUFsbA==
     headers:
       Content-Length: ['145']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110758Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><GetQueueAttributesResponse
-        xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:eu-west-1:000000000000:test-queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1425467277</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1425467277</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>b0db3f8c-c8a3-5238-b721-72fc216d22cc</RequestId></ResponseMetadata></GetQueueAttributesResponse>'}
+    body: {string: '<?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:eu-west-1:000000000000:test-queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1454240694</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1454240694</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>1852bd49-a787-596a-a487-f26e5270ae17</RequestId></ResponseMetadata></GetQueueAttributesResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['1164']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:58 GMT']
-      server: [Server]
-      x-amzn-requestid: [b0db3f8c-c8a3-5238-b721-72fc216d22cc]
+      Connection: [keep-alive]
+      Content-Length: ['1164']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:55 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [1852bd49-a787-596a-a487-f26e5270ae17]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueUrl&Version=2012-11-05&QueueName=test-queue
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlTmFtZT10ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1ZVVy
+      bA==
     headers:
       Content-Length: ['58']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110758Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>e2d59e4b-8b16-52d0-b0bf-d33b62d8d7a2</RequestId></ResponseMetadata></GetQueueUrlResponse>'}
+    body: {string: '<?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://eu-west-1.queue.amazonaws.com/000000000000/test-queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>8dc49172-2a36-54d2-89b5-de55dfc1566b</RequestId></ResponseMetadata></GetQueueUrlResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['332']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:58 GMT']
-      server: [Server]
-      x-amzn-requestid: [e2d59e4b-8b16-52d0-b0bf-d33b62d8d7a2]
+      Connection: [keep-alive]
+      Content-Length: ['332']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:55 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [8dc49172-2a36-54d2-89b5-de55dfc1566b]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueAttributes&QueueUrl=https%3A%2F%2Feu-west-1.queue.amazonaws.com%2F000000000000%2Ftest-queue&Version=2012-11-05&AttributeName.1=All
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlVXJsPWh0dHBzJTNBJTJGJTJGZXUtd2VzdC0xLnF1ZXVl
+      LmFtYXpvbmF3cy5jb20lMkY4NTQ2ODk3MTE4MjQlMkZ0ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1
+      ZUF0dHJpYnV0ZXMmQXR0cmlidXRlTmFtZS4xPUFsbA==
     headers:
       Content-Length: ['145']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110758Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><GetQueueAttributesResponse
-        xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:eu-west-1:000000000000:test-queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1425467277</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1425467277</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>8378fe95-1c22-5ffe-91ba-b3e5f5ec6a8c</RequestId></ResponseMetadata></GetQueueAttributesResponse>'}
+    body: {string: '<?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:eu-west-1:000000000000:test-queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1454240694</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1454240694</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>f8c6aa35-a7a4-5fd1-9b79-e51252535c64</RequestId></ResponseMetadata></GetQueueAttributesResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['1164']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:58 GMT']
-      server: [Server]
-      x-amzn-requestid: [8378fe95-1c22-5ffe-91ba-b3e5f5ec6a8c]
+      Connection: [keep-alive]
+      Content-Length: ['1164']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:55 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [f8c6aa35-a7a4-5fd1-9b79-e51252535c64]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DeleteQueue&QueueUrl=https%3A%2F%2Feu-west-1.queue.amazonaws.com%2F000000000000%2Ftest-queue&Version=2012-11-05
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlVXJsPWh0dHBzJTNBJTJGJTJGZXUtd2VzdC0xLnF1ZXVl
+      LmFtYXpvbmF3cy5jb20lMkY4NTQ2ODk3MTE4MjQlMkZ0ZXN0LXF1ZXVlJkFjdGlvbj1EZWxldGVR
+      dWV1ZQ==
     headers:
       Content-Length: ['118']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110758Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><DeleteQueueResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ResponseMetadata><RequestId>8c604dae-2f89-5847-b00a-00dec647fd35</RequestId></ResponseMetadata></DeleteQueueResponse>'}
+    body: {string: '<?xml version="1.0"?><DeleteQueueResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ResponseMetadata><RequestId>4e65a578-8a78-503c-8c63-ea5f7f809ba5</RequestId></ResponseMetadata></DeleteQueueResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['211']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:58 GMT']
-      server: [Server]
-      x-amzn-requestid: [8c604dae-2f89-5847-b00a-00dec647fd35]
+      Connection: [keep-alive]
+      Content-Length: ['211']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:56 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [4e65a578-8a78-503c-8c63-ea5f7f809ba5]
     status: {code: 200, message: OK}
 - request:
-    body: Action=GetQueueUrl&Version=2012-11-05&QueueName=test-queue
+    body: !!binary |
+      VmVyc2lvbj0yMDEyLTExLTA1JlF1ZXVlTmFtZT10ZXN0LXF1ZXVlJkFjdGlvbj1HZXRRdWV1ZVVy
+      bA==
     headers:
       Content-Length: ['58']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150304T110758Z]
-    method: !!python/unicode 'POST'
-    uri: https://eu-west-1.queue.amazonaws.com:443/
+    method: POST
+    uri: https://eu-west-1.queue.amazonaws.com/
   response:
-    body: {string: !!python/unicode '<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.NonExistentQueue</Code><Message>The
-        specified queue does not exist for this wsdl version.</Message><Detail/></Error><RequestId>4b77392e-98c6-503f-9a60-745e7108254d</RequestId></ErrorResponse>'}
+    body: {string: '<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.NonExistentQueue</Code><Message>The
+        specified queue does not exist for this wsdl version.</Message><Detail/></Error><RequestId>79fea2db-1a13-515b-85e3-edfcefeb302d</RequestId></ErrorResponse>'}
     headers:
-      connection: [keep-alive]
-      content-length: ['333']
-      content-type: [text/xml]
-      date: ['Wed, 04 Mar 2015 11:07:58 GMT']
-      server: [Server]
-      x-amzn-requestid: [4b77392e-98c6-503f-9a60-745e7108254d]
+      Connection: [keep-alive]
+      Content-Length: ['333']
+      Content-Type: [text/xml]
+      Date: ['Sun, 31 Jan 2016 11:44:56 GMT']
+      Server: [Server]
+      x-amzn-RequestId: [79fea2db-1a13-515b-85e3-edfcefeb302d]
     status: {code: 400, message: Bad Request}
 version: 1

--- a/touchdown/tests/cassettes/touchdown.tests.test_aws_vpc_vpc.TestVpc.test_create_and_delete_role.yml
+++ b/touchdown/tests/cassettes/touchdown.tests.test_aws_vpc_vpc.TestVpc.test_create_and_delete_role.yml
@@ -1,211 +1,198 @@
 interactions:
 - request:
-    body: Action=DescribeVpcs&Filter.1.Value.1=test-vpc&Version=2014-10-01&Filter.1.Name=tag%3AName
+    body: !!binary |
+      QWN0aW9uPURlc2NyaWJlVnBjcyZGaWx0ZXIuMS5OYW1lPXRhZyUzQU5hbWUmVmVyc2lvbj0yMDE1
+      LTEwLTAxJkZpbHRlci4xLlZhbHVlLjE9dGVzdC12cGM=
     headers:
       Content-Length: ['89']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172022Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <DescribeVpcsResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n\
-        \    <requestId>218d377e-7ed9-4146-a40b-ba9a4e3fd87f</requestId>\n    <vpcSet/>\n\
-        </DescribeVpcsResponse>"}
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DescribeVpcsResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>e827aa6a-b15f-4731-b355-b8136c829c83</requestId>\n\
+        \    <vpcSet/>\n</DescribeVpcsResponse>"}
     headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:22 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:57 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: Action=CreateVpc&InstanceTenancy=default&Version=2014-10-01&CidrBlock=192.168.0.1%2F25
+    body: !!binary |
+      QWN0aW9uPUNyZWF0ZVZwYyZDaWRyQmxvY2s9MTkyLjE2OC4wLjAlMkYyNSZWZXJzaW9uPTIwMTUt
+      MTAtMDEmSW5zdGFuY2VUZW5hbmN5PWRlZmF1bHQ=
     headers:
       Content-Length: ['86']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172023Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <CreateVpcResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n \
-        \   <requestId>eb3f7f47-f925-4795-a862-c37ae8721bf6</requestId>\n    <vpc>\n\
-        \        <vpcId>vpc-812ff5e4</vpcId>\n        <state>pending</state>\n   \
-        \     <cidrBlock>192.168.0.0/25</cidrBlock>\n        <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n\
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CreateVpcResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>67cc1a0f-22f6-4da5-8489-2c85fe78e2fa</requestId>\n\
+        \    <vpc>\n        <vpcId>vpc-722c0617</vpcId>\n        <state>pending</state>\n\
+        \        <cidrBlock>192.168.0.0/25</cidrBlock>\n        <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n\
         \        <instanceTenancy>default</instanceTenancy>\n    </vpc>\n</CreateVpcResponse>"}
     headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:22 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:57 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeVpcs&Filter.1.Value.1=vpc-812ff5e4&Version=2014-10-01&Filter.1.Name=vpc-id
-    headers:
-      Content-Length: ['89']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172023Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <DescribeVpcsResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n\
-        \    <requestId>e72205a9-5f92-4924-b4f3-a895e38f7624</requestId>\n    <vpcSet>\n\
-        \        <item>\n            <vpcId>vpc-812ff5e4</vpcId>\n            <state>available</state>\n\
-        \            <cidrBlock>192.168.0.0/25</cidrBlock>\n            <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n\
-        \            <instanceTenancy>default</instanceTenancy>\n            <isDefault>false</isDefault>\n\
-        \        </item>\n    </vpcSet>\n</DescribeVpcsResponse>"}
-    headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:22 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: Action=DescribeVpcs&Filter.1.Value.1=vpc-812ff5e4&Version=2014-10-01&Filter.1.Name=vpc-id
-    headers:
-      Content-Length: ['89']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172023Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <DescribeVpcsResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n\
-        \    <requestId>b65edba3-abc8-4521-82a0-63a11e1a795f</requestId>\n    <vpcSet>\n\
-        \        <item>\n            <vpcId>vpc-812ff5e4</vpcId>\n            <state>available</state>\n\
-        \            <cidrBlock>192.168.0.0/25</cidrBlock>\n            <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n\
-        \            <instanceTenancy>default</instanceTenancy>\n            <isDefault>false</isDefault>\n\
-        \        </item>\n    </vpcSet>\n</DescribeVpcsResponse>"}
-    headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:22 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: Action=CreateTags&ResourceId.1=vpc-812ff5e4&Version=2014-10-01&Tag.1.Value=test-vpc&Tag.1.Key=Name
+    body: !!binary |
+      VGFnLjEuVmFsdWU9dGVzdC12cGMmQWN0aW9uPUNyZWF0ZVRhZ3MmUmVzb3VyY2VJZC4xPXZwYy03
+      MjJjMDYxNyZWZXJzaW9uPTIwMTUtMTAtMDEmVGFnLjEuS2V5PU5hbWU=
     headers:
       Content-Length: ['98']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172023Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <CreateTagsResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n\
-        \    <requestId>646fe843-ff27-4611-a11a-f00cec5ad3ed</requestId>\n    <return>true</return>\n\
-        </CreateTagsResponse>"}
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CreateTagsResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>56545bb6-368c-43ed-a662-8af2140315fe</requestId>\n\
+        \    <return>true</return>\n</CreateTagsResponse>"}
     headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:22 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:58 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeVpcs&Filter.1.Value.1=vpc-812ff5e4&Version=2014-10-01&Filter.1.Name=vpc-id
+    body: !!binary |
+      QWN0aW9uPURlc2NyaWJlVnBjcyZGaWx0ZXIuMS5OYW1lPXRhZyUzQU5hbWUmVmVyc2lvbj0yMDE1
+      LTEwLTAxJkZpbHRlci4xLlZhbHVlLjE9dGVzdC12cGM=
     headers:
       Content-Length: ['89']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172023Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <DescribeVpcsResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n\
-        \    <requestId>2ee4b2af-0599-43e2-b3f4-06ee77cb1d73</requestId>\n    <vpcSet>\n\
-        \        <item>\n            <vpcId>vpc-812ff5e4</vpcId>\n            <state>available</state>\n\
-        \            <cidrBlock>192.168.0.0/25</cidrBlock>\n            <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n\
-        \            <tagSet>\n                <item>\n                    <key>Name</key>\n\
-        \                    <value>test-vpc</value>\n                </item>\n  \
-        \          </tagSet>\n            <instanceTenancy>default</instanceTenancy>\n\
-        \            <isDefault>false</isDefault>\n        </item>\n    </vpcSet>\n\
-        </DescribeVpcsResponse>"}
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DescribeVpcsResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>da76c216-f8e7-4b72-b142-612056dc3793</requestId>\n\
+        \    <vpcSet>\n        <item>\n            <vpcId>vpc-722c0617</vpcId>\n \
+        \           <state>available</state>\n            <cidrBlock>192.168.0.0/25</cidrBlock>\n\
+        \            <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n            <tagSet>\n\
+        \                <item>\n                    <key>Name</key>\n           \
+        \         <value>test-vpc</value>\n                </item>\n            </tagSet>\n\
+        \            <instanceTenancy>default</instanceTenancy>\n            <isDefault>false</isDefault>\n\
+        \        </item>\n    </vpcSet>\n</DescribeVpcsResponse>"}
     headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:23 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:58 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeVpcs&Filter.1.Value.1=test-vpc&Version=2014-10-01&Filter.1.Name=tag%3AName
+    body: !!binary |
+      QWN0aW9uPURlc2NyaWJlVnBjcyZGaWx0ZXIuMS5OYW1lPXRhZyUzQU5hbWUmVmVyc2lvbj0yMDE1
+      LTEwLTAxJkZpbHRlci4xLlZhbHVlLjE9dGVzdC12cGM=
     headers:
       Content-Length: ['89']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172023Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <DescribeVpcsResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n\
-        \    <requestId>d5da7af5-51b8-4d01-8b4a-7699384c2e8c</requestId>\n    <vpcSet>\n\
-        \        <item>\n            <vpcId>vpc-812ff5e4</vpcId>\n            <state>available</state>\n\
-        \            <cidrBlock>192.168.0.0/25</cidrBlock>\n            <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n\
-        \            <tagSet>\n                <item>\n                    <key>Name</key>\n\
-        \                    <value>test-vpc</value>\n                </item>\n  \
-        \          </tagSet>\n            <instanceTenancy>default</instanceTenancy>\n\
-        \            <isDefault>false</isDefault>\n        </item>\n    </vpcSet>\n\
-        </DescribeVpcsResponse>"}
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DescribeVpcsResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>ad95e879-b48d-43f3-9c8d-ef8bb1158935</requestId>\n\
+        \    <vpcSet>\n        <item>\n            <vpcId>vpc-722c0617</vpcId>\n \
+        \           <state>available</state>\n            <cidrBlock>192.168.0.0/25</cidrBlock>\n\
+        \            <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n            <tagSet>\n\
+        \                <item>\n                    <key>Name</key>\n           \
+        \         <value>test-vpc</value>\n                </item>\n            </tagSet>\n\
+        \            <instanceTenancy>default</instanceTenancy>\n            <isDefault>false</isDefault>\n\
+        \        </item>\n    </vpcSet>\n</DescribeVpcsResponse>"}
     headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:22 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:58 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DeleteVpc&VpcId=vpc-812ff5e4&Version=2014-10-01
+    body: !!binary |
+      QWN0aW9uPURlc2NyaWJlVnBjcyZGaWx0ZXIuMS5OYW1lPXRhZyUzQU5hbWUmVmVyc2lvbj0yMDE1
+      LTEwLTAxJkZpbHRlci4xLlZhbHVlLjE9dGVzdC12cGM=
+    headers:
+      Content-Length: ['89']
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DescribeVpcsResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>92bb5339-6b48-4c1a-aaa9-3681e2696ad8</requestId>\n\
+        \    <vpcSet>\n        <item>\n            <vpcId>vpc-722c0617</vpcId>\n \
+        \           <state>available</state>\n            <cidrBlock>192.168.0.0/25</cidrBlock>\n\
+        \            <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n            <tagSet>\n\
+        \                <item>\n                    <key>Name</key>\n           \
+        \         <value>test-vpc</value>\n                </item>\n            </tagSet>\n\
+        \            <instanceTenancy>default</instanceTenancy>\n            <isDefault>false</isDefault>\n\
+        \        </item>\n    </vpcSet>\n</DescribeVpcsResponse>"}
+    headers:
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:59 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      QWN0aW9uPURlc2NyaWJlVnBjcyZGaWx0ZXIuMS5OYW1lPXRhZyUzQU5hbWUmVmVyc2lvbj0yMDE1
+      LTEwLTAxJkZpbHRlci4xLlZhbHVlLjE9dGVzdC12cGM=
+    headers:
+      Content-Length: ['89']
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DescribeVpcsResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>581ea599-44b8-4421-9632-3fd3901f327f</requestId>\n\
+        \    <vpcSet>\n        <item>\n            <vpcId>vpc-722c0617</vpcId>\n \
+        \           <state>available</state>\n            <cidrBlock>192.168.0.0/25</cidrBlock>\n\
+        \            <dhcpOptionsId>dopt-ec5b4b8e</dhcpOptionsId>\n            <tagSet>\n\
+        \                <item>\n                    <key>Name</key>\n           \
+        \         <value>test-vpc</value>\n                </item>\n            </tagSet>\n\
+        \            <instanceTenancy>default</instanceTenancy>\n            <isDefault>false</isDefault>\n\
+        \        </item>\n    </vpcSet>\n</DescribeVpcsResponse>"}
+    headers:
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:59 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      QWN0aW9uPURlbGV0ZVZwYyZWcGNJZD12cGMtNzIyYzA2MTcmVmVyc2lvbj0yMDE1LTEwLTAx
     headers:
       Content-Length: ['54']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172023Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <DeleteVpcResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n \
-        \   <requestId>1215f49e-06a1-46e6-bc06-5b8e985bcdcc</requestId>\n    <return>true</return>\n\
-        </DeleteVpcResponse>"}
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DeleteVpcResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>69bbbb16-81c7-466a-a6a5-e86e337e76ca</requestId>\n\
+        \    <return>true</return>\n</DeleteVpcResponse>"}
     headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:23 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:59 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: Action=DescribeVpcs&Filter.1.Value.1=vpc-812ff5e4&Version=2014-10-01&Filter.1.Name=vpc-id
+    body: !!binary |
+      QWN0aW9uPURlc2NyaWJlVnBjcyZGaWx0ZXIuMS5OYW1lPXRhZyUzQU5hbWUmVmVyc2lvbj0yMDE1
+      LTEwLTAxJkZpbHRlci4xLlZhbHVlLjE9dGVzdC12cGM=
     headers:
       Content-Length: ['89']
       Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [Botocore/0.93.0 Python/2.7.6 Darwin/14.1.0]
-      X-Amz-Date: [20150228T172024Z]
-    method: !!python/unicode 'POST'
-    uri: https://ec2.eu-west-1.amazonaws.com:443/
+    method: POST
+    uri: https://ec2.eu-west-1.amazonaws.com/
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-        <DescribeVpcsResponse xmlns=\"http://ec2.amazonaws.com/doc/2014-10-01/\">\n\
-        \    <requestId>afc673a5-3dd9-4bec-8181-fcf609d713b5</requestId>\n    <vpcSet/>\n\
-        </DescribeVpcsResponse>"}
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DescribeVpcsResponse\
+        \ xmlns=\"http://ec2.amazonaws.com/doc/2015-10-01/\">\n    <requestId>614ea3ff-ded0-4129-99e9-1a815d0d524d</requestId>\n\
+        \    <vpcSet/>\n</DescribeVpcsResponse>"}
     headers:
-      content-type: [text/xml;charset=UTF-8]
-      date: ['Sat, 28 Feb 2015 17:20:23 GMT']
-      server: [AmazonEC2]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Sun, 31 Jan 2016 11:28:59 GMT']
+      Server: [AmazonEC2]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/touchdown/tests/test_aws_common.py
+++ b/touchdown/tests/test_aws_common.py
@@ -55,7 +55,7 @@ class TestSimpleDescribeImplementations(unittest.TestCase):
             if issubclass(impl, self.ignore):
                 continue
 
-            if impl.describe_action is None:
+            if getattr(impl, "describe_action", None) is None:
                 continue
 
             service = session.get_service_model(impl.service_name)


### PR DESCRIPTION
This branch refactors IAM server certificates to support 'update by replacement' - any changes to the certificate will result in a new certificate with a new name getting uploaded.

Under the hood this consolidates shared code and reduces duplication and fixes some subtle bugs uncovered in other resources.

This also increases certificate validation that is performed - the private key *must* match the certificate body.