### PR TITLE
[WIP] Add Amazon Certificate Manager support

### DIFF
--- a/docs/config/aws/acm.rst
+++ b/docs/config/aws/acm.rst
@@ -1,0 +1,57 @@
+Amazon Certificate Manager
+==========================
+
+.. module:: touchdown.aws.acm
+   :synopsis: Automated management of DV SSL certificates
+
+Amazon Certificate Manager generates free certificates for TLS with Elastic Load Balancer and CloudFront, and transparently handles rotation and renewal.
+
+When you request a certificate Amazon validate you control the domain by e-mail. For example if you requested a certificate for ``www.example.com`` it attempts to contact:
+
+ * The domain registrant
+ * The technical contact
+ * The administrative contact
+ * ``admin@www.example.com``
+ * ``administrator@www.example.com``
+ * ``hostmaster@www.example.com``
+ * ``postmaster@www.example.com``
+ * ``webmaster@www.example.com``
+
+.. note::
+
+    These certificates can only be used with Amazon services - there is no way to obtain the private certificate.
+
+
+If you already have a certificate that you wish to use with CloudFront or ELB you can upload it with a :py:class:`~touchdown.aws.iam.server_certificate.ServerCertificate`.
+
+
+Creating a certificate
+----------------------
+
+.. class:: Certificate
+
+    To create a certificate you just need to choose the domain it is for::
+
+        certificate = aws.add_acm_certificate(
+            name='www.example.com',
+        )
+
+    .. attribute:: name
+
+        The domain name to request a certificate for.
+
+    .. attribute:: validation_options
+
+        By default ACM will e-mail the contacts for your domain - so `hostmaster@www.example.com` in the previous example. You can override this::
+
+            certificate = aws.add_acm_certificate(
+                name="www.example.com",
+                validation_options=[{
+                    "domain": "www.example.com",
+                    "validation_domain": "example.com",
+                }]
+            )
+
+    .. attribute:: alternate_names
+
+        A list of alternative domain names this cert should be valid for, for example for ``www.example.com`` you might also add ``www.example.net``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,7 @@ Resources
    :doc:`Simple Notification Service <config/aws/sns>` |
    :doc:`Simple Queue Service <config/aws/sqs>` |
    :doc:`Simple Storage Service <config/aws/s3>` |
+   :doc:`SSL Certificates <config/acm>` |
    :doc:`Transcoding <config/aws/elastictranscoder>` |
    :doc:`VPNs <config/aws/vpn>`
 

--- a/touchdown/aws/__init__.py
+++ b/touchdown/aws/__init__.py
@@ -15,6 +15,7 @@
 from . import (
     account,
     vpc,
+    acm,
     apigateway,
     ec2,
     cloudfront,
@@ -40,6 +41,7 @@ from . import (
 __all__ = [
     'account',
     'vpc',
+    'acm',
     'apigateway',
     'ec2',
     'cloudfront',

--- a/touchdown/aws/acm/__init__.py
+++ b/touchdown/aws/acm/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .certificate import Certificate
+
+__all__ = [
+    'Certificate',
+]

--- a/touchdown/aws/acm/certificate.py
+++ b/touchdown/aws/acm/certificate.py
@@ -1,0 +1,78 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from touchdown.core import argument, serializers
+from touchdown.core.plan import Plan, Present
+from touchdown.core.resource import Resource
+
+from ..account import BaseAccount
+from ..common import SimpleApply, SimpleDescribe, SimpleDestroy
+
+
+class DomainValidationOption(Resource):
+
+    domain = argument.String(name="DomainName")
+    validation_domain = argument.String(name="ValidationDomain")
+
+
+class Certificate(Resource):
+
+    resource_name = "acm_certificate"
+
+    name = argument.String(field="DomainName")
+    arn = argument.Output("CertificateArn")
+    alternate_names = argument.List(
+        argument.String(),
+        field="SubjectAlternativeNames",
+    )
+    validation_options = argument.ResourceList(
+        DomainValidationOption,
+        field="DomainValidationOptions",
+    )
+    account = argument.Resource(BaseAccount)
+
+
+class Describe(SimpleDescribe, Plan):
+
+    resource = Certificate
+    service_name = "acm"
+    describe_action = "list_certificates"
+    describe_envelope = "CertificateSummaryList"
+    describe_filters = {}
+    key = "CertificateArn"
+
+    def describe_object_matches(self, obj):
+        return obj["DomainName"] == self.resource.name
+
+
+class Apply(SimpleApply, Describe):
+
+    create_action = "request_certificate"
+    create_response = "id-only"
+    waiter = "certificate_issued"
+
+    signature = [
+        Present("name"),
+        Present("bucket"),
+    ]
+
+
+class Destroy(SimpleDestroy, Describe):
+
+    destroy_action = "delete_certificate"
+
+    def get_destroy_serializer(self):
+        return serializers.Dict(
+            CertificateArn=self.resource.arn,
+        )

--- a/touchdown/aws/cloudfront/distribution.py
+++ b/touchdown/aws/cloudfront/distribution.py
@@ -20,6 +20,7 @@ from touchdown.core.resource import Resource
 
 from .. import route53
 from ..account import BaseAccount
+from ..acm import Certificate
 from ..common import (
     RefreshMetadata,
     SimpleApply,
@@ -222,6 +223,13 @@ class Distribution(Resource):
         serializer=serializers.Property("ServerCertificateId"),
     )
 
+    acm_certificate = argument.Resource(
+        Certificate,
+        field="Certificate",
+        group="viewer-certificate",
+        serializer=serializers.Property("CertificateArn"),
+    )
+
     ssl_support_method = argument.String(
         default="sni-only",
         choices=["sni-only", "vip"],
@@ -240,7 +248,9 @@ class Distribution(Resource):
         field="ViewerCertificate",
         serializer=serializers.Resource(
             group="viewer-certificate",
-            CertificateSource=serializers.Expression(lambda r, o: "iam" if o.ssl_certificate else "cloudfront"),
+            CertificateSource=serializers.Expression(
+                lambda r, o: "acm" if o.acm_certificate else "iam" if o.ssl_certificate else "cloudfront"
+            ),
         ),
     )
 

--- a/touchdown/aws/data/acm/2015-12-08/waiter-2.json
+++ b/touchdown/aws/data/acm/2015-12-08/waiter-2.json
@@ -1,0 +1,48 @@
+{
+  "version": 2,
+  "waiters": {
+    "CertificateIssued": {
+      "delay": 10,
+      "maxAttempts": 360,
+      "operation": "DescribeCertificate",
+      "acceptors": [
+        {
+          "matcher": "pathAll",
+          "expected": "ISSUED",
+          "argument": "Certificate.Status",
+          "state": "success"
+        },
+        {
+          "matcher": "pathAll",
+          "expected": "INACTIVE",
+          "argument": "Certificate.Status",
+          "state": "failure"
+        },
+        {
+          "matcher": "pathAll",
+          "expected": "EXPIRED",
+          "argument": "Certificate.Status",
+          "state": "failure"
+        },
+        {
+          "matcher": "pathAll",
+          "expected": "VALIDATION_TIMED_OUT",
+          "argument": "Certificate.Status",
+          "state": "failure"
+        },
+        {
+          "matcher": "pathAll",
+          "expected": "REVOKED",
+          "argument": "Certificate.Status",
+          "state": "failure"
+        },
+        {
+          "matcher": "pathAll",
+          "expected": "FAILED",
+          "argument": "Certificate.Status",
+          "state": "failure"
+        }
+      ]
+    }
+  }
+}

--- a/touchdown/aws/elb/load_balancer.py
+++ b/touchdown/aws/elb/load_balancer.py
@@ -21,6 +21,7 @@ from touchdown.core.resource import Resource
 
 from .. import route53
 from ..account import BaseAccount
+from ..acm import Certificate
 from ..common import SimpleApply, SimpleDescribe, SimpleDestroy
 from ..iam import ServerCertificate
 from ..s3 import Bucket
@@ -39,6 +40,11 @@ class Listener(Resource):
         ServerCertificate,
         field="SSLCertificiateId",
         serializer=serializers.Property("Arn"),
+    )
+    acm_certificate = argument.Resource(
+        Certificate,
+        field="SSLCertificiateId",
+        serializer=serializers.Property("CertificateArn"),
     )
 
 


### PR DESCRIPTION
Integrate the new `acm` service into touchdown:

 * [x] Add new `acm_certificate` resource
 * [x] Add docs
 * [x] Add botocore waiter
 * [x] Add elb integration
 * [x] Add cloudfront integration