### PR TITLE
[WIP] Support for automatic allocation of network space

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,23 @@
 Changelog for Touchdown
 =======================
 
-0.8.1 (unreleased)
+0.9.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Touchdown can now manage allocation of parts of a network range through the
+  `ip_network` type::
+
+      network = config.add_ip_network(
+          name='subnets',
+          network='10.41.0.0/20',
+      )
+
+      app_serves = network.add_ip_allocation(
+          name='app_servers',
+          size='25',
+      )
+
+  This would allocate the first available `/25` in `10.41.0.0/20`.
 
 
 0.8.0 (2016-03-15)

--- a/touchdown/config/__init__.py
+++ b/touchdown/config/__init__.py
@@ -15,9 +15,10 @@
 from .ini import IniFile
 from .integer import Integer
 from .list import List
+from .network import IPNetwork
 from .string import String
 from .variable import Variable
-from .ip_network import Network
+from .ip_allocations import Allocations
 from .ip_allocation import Allocation
 
 
@@ -27,6 +28,7 @@ __all__ = [
     "List",
     "String",
     "Variable",
-    "Network",
+    "IPNetwork",
+    "Allocations",
     "Allocation",
 ]

--- a/touchdown/config/__init__.py
+++ b/touchdown/config/__init__.py
@@ -17,6 +17,8 @@ from .integer import Integer
 from .list import List
 from .string import String
 from .variable import Variable
+from .ip_network import Network
+from .ip_allocation import Allocation
 
 
 __all__ = [
@@ -25,4 +27,6 @@ __all__ = [
     "List",
     "String",
     "Variable",
+    "Network",
+    "Allocation",
 ]

--- a/touchdown/config/ini.py
+++ b/touchdown/config/ini.py
@@ -64,6 +64,13 @@ class Describe(Plan):
         except (configparser.NoSectionError, configparser.NoOptionError):
             raise KeyError(key)
 
+    def walk(self, key):
+        c = self.read()
+        try:
+            return c.items(key)
+        except configparser.NoSectionError:
+            return []
+
     def get_actions(self):
         self.object = self.read()
         return []

--- a/touchdown/config/ini.py
+++ b/touchdown/config/ini.py
@@ -48,6 +48,22 @@ class Describe(Plan):
             pass
         return config
 
+    def set(self, key, value):
+        section, name = key.rsplit(".", 1)
+        c = self.read()
+        if not c.has_section(section):
+            c.add_section(section)
+        c.set(section, name, value)
+        self.write(c)
+
+    def get(self, key):
+        section, name = key.rsplit(".", 1)
+        c = self.read()
+        try:
+            return c.get(section, name)
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            raise KeyError(key)
+
     def get_actions(self):
         self.object = self.read()
         return []

--- a/touchdown/config/ip_allocation.py
+++ b/touchdown/config/ip_allocation.py
@@ -1,0 +1,92 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from touchdown.core import argument, plan, resource
+from touchdown.core.action import Action
+
+from . import ip_network, variable
+
+
+class Allocation(resource.Resource):
+
+    resource_name = "ip_allocation"
+    field_order = ['network', 'name']
+
+    name = argument.String()
+    size = argument.Integer(default=25)
+    network = argument.Resource(ip_network.Network)
+
+    def clean_name(self, name):
+        return self.network.name + "." + name
+
+
+class ApplyAction(Action):
+
+    @property
+    def description(self):
+        yield "Allocate a /{} within {}".format(
+            self.resource.size,
+            self.resource.network.network,
+        )
+
+    def run(self):
+        allocator = self.runner.get_service(self.resource.network, "ip_allocator")
+        allocation = allocator.allocate(self.resource.name, self.resource.size)
+        self.runner.get_service(self.resource, "set").execute(allocation)
+
+
+class Apply(plan.Plan):
+
+    resource = Allocation
+    name = "apply"
+
+    def get_actions(self):
+        try:
+            self.runner.get_service(self.resource, "get").execute()
+        except KeyError:
+            yield ApplyAction(self)
+
+
+class Get(plan.Plan):
+
+    resource = Allocation
+    name = "get"
+
+    def execute(self):
+        conf = self.runner.get_service(
+            self.resource.network.config,
+            "describe",
+        )
+        return conf.get(self.resource.name)
+
+
+class Set(plan.Plan):
+
+    resource = Allocation
+    name = "set"
+
+    def execute(self, value):
+        conf = self.runner.get_service(
+            self.resource.network.config,
+            "describe",
+        )
+        return conf.set(self.resource.name, value)
+
+
+class Describe(variable.Describe):
+
+    resource = Allocation
+
+
+argument.String.register_adapter(Allocation, variable.VariableAsString)

--- a/touchdown/config/ip_allocation.py
+++ b/touchdown/config/ip_allocation.py
@@ -43,7 +43,7 @@ class ApplyAction(Action):
     def run(self):
         allocator = self.runner.get_service(self.resource.network, "ip_allocator")
         allocation = allocator.allocate(self.resource.name, self.resource.size)
-        self.runner.get_service(self.resource, "set").execute(allocation)
+        self.runner.get_service(self.resource, "set").execute(str(allocation))
 
 
 class Apply(plan.Plan):

--- a/touchdown/config/ip_allocation.py
+++ b/touchdown/config/ip_allocation.py
@@ -76,6 +76,9 @@ class Set(plan.Plan):
     resource = Allocation
     name = "set"
 
+    def from_string(self, value):
+        return value
+
     def execute(self, value):
         conf = self.runner.get_service(
             self.resource.network.config,

--- a/touchdown/config/ip_allocation.py
+++ b/touchdown/config/ip_allocation.py
@@ -15,7 +15,7 @@
 from touchdown.core import argument, plan, resource
 from touchdown.core.action import Action
 
-from . import ip_network, variable
+from . import ip_allocations, variable
 
 
 class Allocation(resource.Resource):
@@ -25,7 +25,7 @@ class Allocation(resource.Resource):
 
     name = argument.String()
     size = argument.Integer(default=25)
-    network = argument.Resource(ip_network.Network)
+    network = argument.Resource(ip_allocations.Allocations)
 
     def clean_name(self, name):
         return self.network.name + "." + name

--- a/touchdown/config/ip_allocations.py
+++ b/touchdown/config/ip_allocations.py
@@ -17,14 +17,14 @@ import threading
 
 import netaddr
 
-from touchdown.core import argument, plan, resource
+from touchdown.core import argument, plan, resource, serializers
 
 from . import IniFile
 
 
-class Network(resource.Resource):
+class Allocations(resource.Resource):
 
-    resource_name = "ip_network"
+    resource_name = "ip_allocations"
 
     name = argument.String()
     network = argument.IPNetwork()
@@ -33,34 +33,38 @@ class Network(resource.Resource):
 
 class Describe(plan.Plan):
 
-    resource = Network
+    resource = Allocations
     name = "describe"
+
+    def network(self):
+        return serializers.maybe(self.resource.network).render(
+            self.runner,
+            self.resource,
+        )
 
     def get_actions(self):
         conf = self.runner.get_service(self.resource.config, "describe")
         self.object = {}
         for key, value in conf.walk(self.resource.name):
             self.object[key] = value
-        self.runner.get_service(self.resource, "ip_allocator").load(self.object)
+        self.runner.get_service(self.resource, "ip_allocator").load(self.network(), self.object)
         return []
 
 
-class NetworkApply(plan.Plan):
+class IpAllocator(plan.Plan):
 
     """
     Given an ipaddress.ip_network, manage allocating it into smaller allocations
     """
 
-    resource = Network
+    resource = Allocations
     name = "ip_allocator"
 
     def __init__(self, *args, **kwargs):
-        super(NetworkApply, self).__init__(*args, **kwargs)
-        self.allocations = {}
-        self.free = {int(self.resource.network.prefixlen): [self.resource.network]}
+        super(IpAllocator, self).__init__(*args, **kwargs)
         self.allocation_lock = threading.Lock()
 
-    def load(self, state):
+    def load(self, network, state):
         """
         Given a list of allocations that have already been applied, ensure that
         `self.allocations` and `self.free` is correct.
@@ -68,17 +72,19 @@ class NetworkApply(plan.Plan):
         with self.allocation_lock:
             self.allocations = state
             state_set = netaddr.IPSet(state.values())
-            network_set = netaddr.IPSet([self.resource.network])
+            network_set = netaddr.IPSet([network])
             self.free = collections.defaultdict(list)
             for network in (network_set - state_set).iter_cidrs():
                 self.free[network.prefixlen].append(network)
 
     def allocate(self, name, prefixlen):
-        if prefixlen < int(self.resource.network.prefixlen):
-            raise ValueError("Cannot fit /{} inside /{}".format(prefixlen, self.resource.network.prefixlen))
+        network = self.runner.get_service(self.resource, "describe").network()
+
+        if prefixlen < int(network.prefixlen):
+            raise ValueError("Cannot fit /{} inside /{}".format(prefixlen, network.prefixlen))
 
         with self.allocation_lock:
-            for i in range(prefixlen, int(self.resource.network.prefixlen) - 1, -1):
+            for i in range(prefixlen, int(network.prefixlen) - 1, -1):
                 if self.free.get(i, None):
                     selected = self.free[i].pop()
                     break

--- a/touchdown/config/ip_network.py
+++ b/touchdown/config/ip_network.py
@@ -1,0 +1,68 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+
+from touchdown.core import argument, plan, resource
+
+from . import IniFile
+
+
+class Network(resource.Resource):
+
+    resource_name = "ip_network"
+
+    name = argument.String()
+    network = argument.IPNetwork()
+    config = argument.Resource(IniFile)
+
+
+class NetworkApply(plan.Plan):
+
+    """
+    Given an ipaddress.ip_network, manage allocating it into smaller allocations
+    """
+
+    resource = Network
+    name = "ip_allocator"
+
+    def __init__(self, *args, **kwargs):
+        super(NetworkApply, self).__init__(*args, **kwargs)
+        self.allocations = {}
+        self.free = {int(self.resource.network.prefixlen): [self.resource.network]}
+        self.allocation_lock = threading.Lock()
+
+    def allocate(self, name, prefixlen):
+        if prefixlen < int(self.resource.network.prefixlen):
+            raise ValueError("Cannot fit /{} inside /{}".format(prefixlen, self.resource.network.prefixlen))
+
+        with self.allocation_lock:
+            for i in range(prefixlen, int(self.resource.network.prefixlen) - 1, -1):
+                if self.free.get(i, None):
+                    selected = self.free[i].pop()
+                    break
+            else:
+                raise ValueError(
+                    "There is not enough space left to allocate a /{}".format(
+                        prefixlen
+                    )
+                )
+
+            while int(selected.prefixlen) < prefixlen:
+                selected, leftover = selected.subnet(selected.prefixlen + 1)
+                self.free[int(leftover.prefixlen)] = [leftover]
+
+            self.allocations[name] = selected
+
+        return selected

--- a/touchdown/config/network.py
+++ b/touchdown/config/network.py
@@ -1,0 +1,45 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netaddr
+
+from touchdown.core import argument
+
+from . import variable
+
+
+class IPNetwork(variable.Variable):
+
+    resource_name = "ip_network"
+
+    default = argument.String()
+    min = argument.Integer()
+    max = argument.Integer()
+
+
+class Set(variable.Set):
+    resource = IPNetwork
+
+    def to_lines(self, value):
+        return [str(value)]
+
+
+class Get(variable.Get):
+    resource = IPNetwork
+
+    def from_lines(self, value):
+        return netaddr.IPNetwork(value[0])
+
+
+argument.IPNetwork.register_adapter(IPNetwork, variable.VariableAsString)

--- a/touchdown/tests/test_config.py
+++ b/touchdown/tests/test_config.py
@@ -115,6 +115,24 @@ class _Mixins(object):
         self.assertRaises(errors.NothingChanged, self.call, "apply")
         assert self.get("lists.variable2") == self.get("lists.variable2")
 
+    def test_retain_ips(self):
+        net = self.config.add_ip_network(
+            name="subnets",
+            network='10.30.0.0/20',
+        )
+        net.add_ip_allocation(
+            name='app-a',
+            size=25,
+        )
+        net.add_ip_allocation(
+            name='app-b',
+            size=25,
+        )
+        self.call("apply")
+        self.assertRaises(errors.NothingChanged, self.call, "apply")
+        assert self.get("subnets.app-a") == '10.30.0.0/25'
+        assert self.get("subnets.app-b") == '10.30.0.128/25'
+
     def test_echo_string(self):
         self.workspace.add_echo(
             text=self.strings_variable1,

--- a/touchdown/tests/test_config.py
+++ b/touchdown/tests/test_config.py
@@ -116,7 +116,7 @@ class _Mixins(object):
         assert self.get("lists.variable2") == self.get("lists.variable2")
 
     def test_retain_ips(self):
-        net = self.config.add_ip_network(
+        net = self.config.add_ip_allocations(
             name="subnets",
             network='10.30.0.0/20',
         )
@@ -162,9 +162,10 @@ class TestIpNetwork(_Mixins, unittest.TestCase):
         return folder.add_file(name='test.cfg')
 
     def test_ensure_allocator_state_preserved(self):
-        net = self.config.add_ip_network(
+        network = self.config.add_ip_network(name="environment.network")
+        net = self.config.add_ip_allocations(
             name="subnets",
-            network='10.30.0.0/20',
+            network=network,
         )
         net.add_ip_allocation(
             name='app-a',
@@ -174,6 +175,7 @@ class TestIpNetwork(_Mixins, unittest.TestCase):
             name='app-b',
             size=25,
         )
+        self.call("set", "environment.network", "10.30.0.0/20")
         self.call("set", "subnets.app-a", "10.30.0.0/25")
         self.call("apply")
         self.assertRaises(errors.NothingChanged, self.call, "apply")


### PR DESCRIPTION
This PR adds a new type called an `ip_network` that is attached to a config object (for example, an ini file). The type is given a network range and manages splitting it up into smaller pieces (`ip_allocations`).

(This functionality is built with Takeoff in mind)

 * [x] When i run touchdown any allocations that are not present in the config object should be allocated and saved
 * [x] If touchdown is running in multi-threaded mode it should be able to handle multiple threads asking for allocations.
 * [x] The allocation names should include the `ip_network` name when accessed with `touchdown get`
 * [x] If I re-run touchdown then the allocator state should be seeded from the configuration file.
 * [x] You should be able to use another variable as the input to an `ip_network`
 * [ ] You should be able to pass an `ip_allocation` directly to a NetworkACL
 * [ ] You should be able to pass an `ip_allocation` directly to a Subnet
 * [ ] You should be able to pass an `ip_allocation` directly to a SecurityGroup
