### PR TITLE
[WIP] Support VPC Endpoints

### DIFF
--- a/touchdown/aws/vpc/__init__.py
+++ b/touchdown/aws/vpc/__init__.py
@@ -14,6 +14,7 @@
 
 from .customer_gateway import CustomerGateway
 from .elastic_ip import ElasticIp
+from .endpoint import Endpoint
 from .internet_gateway import InternetGateway
 from .nat_gateway import NatGateway
 from .network_acl import NetworkACL
@@ -29,6 +30,7 @@ __all__ = [
     'VPC',
     'CustomerGateway',
     'ElasticIp',
+    'Endpoint',
     'InternetGateway',
     'NatGateway',
     'NetworkACL',

--- a/touchdown/aws/vpc/endpoint.py
+++ b/touchdown/aws/vpc/endpoint.py
@@ -1,0 +1,92 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from touchdown.config import String
+from touchdown.core import argument, serializers
+from touchdown.core.plan import Plan
+from touchdown.core.resource import Resource
+
+from ..common import Action, SimpleApply, SimpleDescribe, SimpleDestroy
+from .route_table import RouteTable
+from .vpc import VPC
+
+
+class Endpoint(Resource):
+
+    resource_name = "endpoint"
+
+    id = argument.Resource(String)
+    name = argument.String()
+    service = argument.String(
+        field="ServiceName",
+        choices=["s3"],
+    )
+    route_tables = argument.ResourceList(RouteTable, field="RouteTableIds")
+    policy = argument.String(field="PolicyDocument")
+    vpc = argument.Resource(VPC, field='VpcId')
+
+
+class NameAction(Action):
+
+    @property
+    def description(self):
+        yield "Store vpc_endpoint id as setting {!r}".format(self.resource.id.name)
+
+    def run(self):
+        self.runner.get_service(self.resource.id, "set").execute(
+            self.plan.resource_id
+        )
+
+
+class Describe(SimpleDescribe, Plan):
+
+    resource = Endpoint
+    service_name = 'ec2'
+    api_version = '2015-10-01'
+    describe_action = "describe_vpc_endpoints"
+    describe_envelope = "VpcEndpoints"
+    key = "VpcEndpointId"
+
+    def get_describe_filters(self):
+        vpc = self.runner.get_plan(self.resource.vpc)
+        if not vpc.resource_id:
+            return None
+
+        vpce_id, _ = self.runner.get_service(self.resource.id, "get").execute()
+        if not vpce_id:
+            return None
+
+        return {
+            "Filters": [
+                {"Name": "vpc-endpoint-id", "Values": [vpce_id]},
+            ]
+        }
+
+
+class Apply(SimpleApply, Describe):
+
+    create_action = "create_vpc_endpoint"
+
+    def name_object(self):
+        yield NameAction(self)
+
+
+class Destroy(SimpleDestroy, Describe):
+
+    destroy_action = "delete_vpc_endpoints"
+
+    def get_destroy_serializer(self):
+        return serializers.Dict(
+            VpcEndpointIds=serializers.ListOfOne(serializers.Identifier()),
+        )

--- a/touchdown/tests/stubs/aws/__init__.py
+++ b/touchdown/tests/stubs/aws/__init__.py
@@ -17,8 +17,11 @@ from .distribution import DistributionStubber
 from .ec2_instance import EC2InstanceStubber
 from .event_rule import EventRuleStubber
 from .hosted_zone import HostedZoneStubber
+from .endpoint import VpcEndpointStubber
+from .route_table import RouteTableStubber
 from .volume_attachment import VolumeAttachmentStubber
 from .volume import VolumeStubber
+from .vpc import VpcStubber
 
 
 __all__ = [
@@ -27,6 +30,9 @@ __all__ = [
     'EC2InstanceStubber',
     'EventRuleStubber',
     'HostedZoneStubber',
+    'RouteTableStubber',
     'VolumeAttachmentStubber',
     'VolumeStubber',
+    'VpcEndpointStubber',
+    'VpcStubber',
 ]

--- a/touchdown/tests/stubs/aws/endpoint.py
+++ b/touchdown/tests/stubs/aws/endpoint.py
@@ -22,6 +22,34 @@ class VpcEndpointStubber(ServiceStubber):
     def make_id(self, name):
         return 'vpce-' + super(VpcEndpointStubber, self).make_id(name)[:8]
 
+    def add_describe_vpc_endpoints_one_response_for_vpceid(self, vpceid):
+        return self.add_response(
+            'describe_vpc_endpoints',
+            service_response={
+                'VpcEndpoints': [{
+                    'VpcEndpointId': vpceid,
+                }]
+            },
+            expected_params={
+                'Filters': [
+                    {'Name': 'vpc-endpoint-id', 'Values': [vpceid]}
+                ]
+            },
+        )
+
+    def add_describe_vpc_endpoints_empty_response(self, vpceid):
+        return self.add_response(
+            'describe_vpc_endpoints',
+            service_response={
+                'VpcEndpoints': [],
+            },
+            expected_params={
+                'Filters': [
+                    {'Name': 'vpc-endpoint-id', 'Values': [vpceid]}
+                ]
+            },
+        )
+
     def add_create_vpc_endpoint(self, vpc_id, route_table_ids, service_name='s3'):
         return self.add_response(
             'create_vpc_endpoint',
@@ -34,5 +62,15 @@ class VpcEndpointStubber(ServiceStubber):
                 'VpcId': vpc_id,
                 'RouteTableIds': route_table_ids,
                 'ServiceName': service_name,
+            },
+        )
+
+    def add_delete_vpc_endpoint(self, vpce_id):
+        return self.add_response(
+            'delete_vpc_endpoints',
+            service_response={
+            },
+            expected_params={
+                'VpcEndpointIds': [vpce_id],
             },
         )

--- a/touchdown/tests/stubs/aws/endpoint.py
+++ b/touchdown/tests/stubs/aws/endpoint.py
@@ -1,0 +1,38 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .service import ServiceStubber
+
+
+class VpcEndpointStubber(ServiceStubber):
+
+    client_service = 'ec2'
+
+    def make_id(self, name):
+        return 'vpce-' + super(VpcEndpointStubber, self).make_id(name)[:8]
+
+    def add_create_vpc_endpoint(self, vpc_id, route_table_ids, service_name='s3'):
+        return self.add_response(
+            'create_vpc_endpoint',
+            service_response={
+                'VpcEndpoint': {
+                    'VpcEndpointId': self.make_id(vpc_id + service_name)
+                }
+            },
+            expected_params={
+                'VpcId': vpc_id,
+                'RouteTableIds': route_table_ids,
+                'ServiceName': service_name,
+            },
+        )

--- a/touchdown/tests/stubs/aws/route_table.py
+++ b/touchdown/tests/stubs/aws/route_table.py
@@ -1,0 +1,38 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .service import ServiceStubber
+
+
+class RouteTableStubber(ServiceStubber):
+
+    client_service = 'ec2'
+
+    def make_id(self, name):
+        return 'rt-' + super(RouteTableStubber, self).make_id(name)[:8]
+
+    def add_describe_route_tables_one_response_by_name(self):
+        return self.add_response(
+            'describe_route_tables',
+            service_response={
+                'RouteTables': [{
+                    'RouteTableId': self.make_id(self.resource.name),
+                }],
+            },
+            expected_params={
+                'Filters': [
+                    {'Name': 'tag:Name', 'Values': [self.resource.name]}
+                ],
+            },
+        )

--- a/touchdown/tests/stubs/aws/vpc.py
+++ b/touchdown/tests/stubs/aws/vpc.py
@@ -1,0 +1,38 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .service import ServiceStubber
+
+
+class VpcStubber(ServiceStubber):
+
+    client_service = 'ec2'
+
+    def make_id(self, name):
+        return 'vpc-' + super(VpcStubber, self).make_id(name)[:8]
+
+    def add_describe_vpcs_one_response_by_name(self):
+        return self.add_response(
+            'describe_vpcs',
+            service_response={
+                'Vpcs': [{
+                    'VpcId': self.make_id(self.resource.name),
+                }],
+            },
+            expected_params={
+                'Filters': [
+                    {'Name': 'tag:Name', 'Values': [self.resource.name]}
+                ],
+            },
+        )

--- a/touchdown/tests/stubs/folder.py
+++ b/touchdown/tests/stubs/folder.py
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .folder import TemporaryFolder
+import shutil
+import tempfile
 
-__all__ = [
-    'TemporaryFolder',
-]
+
+class TemporaryFolder(object):
+
+    def __enter__(self):
+        self.folder = tempfile.mkdtemp()
+        return self
+
+    def __exit__(self, *args):
+        shutil.rmtree(self.folder)

--- a/touchdown/tests/test_aws_vpc_endpoint.py
+++ b/touchdown/tests/test_aws_vpc_endpoint.py
@@ -1,0 +1,67 @@
+# Copyright 2015 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from touchdown.tests.aws import StubberTestCase
+from touchdown.tests.stubs import TemporaryFolder
+from touchdown.tests.stubs.aws import (
+    RouteTableStubber,
+    VpcEndpointStubber,
+    VpcStubber,
+)
+
+
+class TestVpcEndpoint(StubberTestCase):
+
+    def test_create_endpoint(self):
+        goal = self.create_goal('apply')
+
+        vpc = self.fixtures.enter_context(VpcStubber(
+            goal.get_service(
+                self.aws.get_vpc(name='test-vpc'),
+                'describe',
+            )
+        ))
+        vpc.add_describe_vpcs_one_response_by_name()
+
+        route_table = self.fixtures.enter_context(RouteTableStubber(
+            goal.get_service(
+                vpc.resource.get_route_table(name='test-route-table'),
+                'describe',
+            )
+        ))
+        route_table.add_describe_route_tables_one_response_by_name()
+
+        folder = self.workspace.add_local_folder(
+            name=self.fixtures.enter_context(TemporaryFolder()).folder,
+        )
+        config = folder.add_file(name="text.cfg").add_ini_file()
+        name = config.add_string(name="vpc.endpoint-id")
+
+        endpoint = self.fixtures.enter_context(VpcEndpointStubber(
+            goal.get_service(
+                vpc.resource.add_endpoint(
+                    name='is-this-even-used',
+                    id=name,
+                    service='s3',
+                    route_tables=[route_table.resource],
+                ),
+                'apply',
+            )
+        ))
+        endpoint.add_create_vpc_endpoint(
+            vpc.make_id(vpc.resource.name),
+            [route_table.make_id(route_table.resource.name)],
+        )
+
+        goal.execute()


### PR DESCRIPTION
VPC Endpoints represent another exciting step towards non-taggable non-nameable resources. As such you must provide touchdown with a config object when setting up an endpoint so it can track the ID of the endpoint it creates in local state. :sob: 