### PR TITLE
Allow bundles to generate outputs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Changelog for Touchdown
 0.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Allow a bundle to generate outputs that can then feed other aspects of the
+  deployment process.
 
 
 0.12.0 (2016-06-09)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-botocore==1.4.22
+botocore==1.4.27
 jmespath==0.9.0
 netaddr==0.7.18
 contextlib2==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'contextlib2',
         'netaddr',
         'fuselage>=0.0.10',
-        'botocore>=1.4.19',
+        'botocore>=1.4.27',
         'progressbar2>=3.6.0',
         'requests',
         'python-gnupg',

--- a/touchdown/aws/lambda_/function.py
+++ b/touchdown/aws/lambda_/function.py
@@ -74,6 +74,7 @@ class Function(Resource):
 
     code = argument.Function(
         field="Code",
+        update=False,
         serializer=serializers.Dict(
             ZipFile=FunctionSerializer(),
         )
@@ -81,6 +82,7 @@ class Function(Resource):
 
     code_from_bytes = argument.String(
         field="Code",
+        update=False,
         serializer=serializers.Dict(
             ZipFile=serializers.String(),
         )
@@ -89,6 +91,7 @@ class Function(Resource):
     code_from_s3 = argument.Resource(
         "touchdown.aws.s3.file.File",
         field="Code",
+        update=False,
         serializer=serializers.Dict(
             S3Bucket=serializers.Property("Bucket"),
             S3Key=serializers.Property("Key"),
@@ -168,6 +171,10 @@ class Apply(SimpleApply, Describe):
                 self.client.update_function_code,
                 serializers.Resource(Publish=True),
             )
+
+        for obj in super(Apply, self).update_object():
+            yield obj
+
 
 
 class Destroy(SimpleDestroy, Describe):

--- a/touchdown/aws/lambda_/function.py
+++ b/touchdown/aws/lambda_/function.py
@@ -163,15 +163,10 @@ class Apply(SimpleApply, Describe):
                         update_code = True
 
         if update_code:
-            kwargs = {
-                "FunctionName": self.resource.name,
-                "Publish": True,
-            }
-            kwargs.update(serialized['Code'])
             yield self.generic_action(
                 "Update function code",
                 self.client.update_function_code,
-                **kwargs
+                serializers.Resource(Publish=True),
             )
 
 

--- a/touchdown/aws/lambda_/function.py
+++ b/touchdown/aws/lambda_/function.py
@@ -58,8 +58,8 @@ class Function(Resource):
     arn = argument.Output("FunctionArn")
 
     name = argument.String(field="FunctionName", min=1, max=140)
-    description = argument.String(name="Description", max=256)
-    timeout = argument.Integer(name="Timeout", default=3)
+    description = argument.String(field="Description", max=256)
+    timeout = argument.Integer(field="Timeout", default=3)
     runtime = argument.String(
         field="Runtime",
         default='python2.7',
@@ -96,8 +96,8 @@ class Function(Resource):
         )
     )
 
-    memory = argument.Integer(name="MemorySize", default=128, min=128, max=1536)
-    publish = argument.Boolean(name="Publish", default=True)
+    memory = argument.Integer(field="MemorySize", default=128, min=128, max=1536)
+    publish = argument.Boolean(field="Publish", default=True)
 
     security_groups = argument.ResourceList(SecurityGroup, field="SecurityGroupIds", group="vpc_config")
     subnets = argument.ResourceList(Subnet, field="SubnetIds", group="vpc_config")

--- a/touchdown/aws/lambda_/function.py
+++ b/touchdown/aws/lambda_/function.py
@@ -55,7 +55,7 @@ class FunctionSerializer(serializers.Serializer):
         zf.close()
         return buf.getvalue()
 
-argument.String.register_adapter(types.FunctionType, lambda r: FunctionSerializer(r))
+argument.Bytes.register_adapter(types.FunctionType, lambda r: FunctionSerializer(r))
 
 
 class Function(Resource):
@@ -79,11 +79,11 @@ class Function(Resource):
         serializer=serializers.Property("Arn"),
     )
 
-    code = argument.String(
+    code = argument.Bytes(
         field="Code",
         update=False,
         serializer=serializers.Dict(
-            ZipFile=serializers.String(),
+            ZipFile=serializers.Bytes(),
         )
     )
 

--- a/touchdown/aws/lambda_/function.py
+++ b/touchdown/aws/lambda_/function.py
@@ -19,7 +19,7 @@ import itertools
 import types
 import zipfile
 
-from six import StringIO
+from six import BytesIO
 
 from touchdown.aws.iam import Role
 from touchdown.aws.vpc import SecurityGroup, Subnet
@@ -45,7 +45,7 @@ class FunctionSerializer(serializers.Serializer):
         return info
 
     def render(self, runner, func):
-        buf = StringIO()
+        buf = BytesIO()
         zf = zipfile.ZipFile(
             buf,
             mode='w',

--- a/touchdown/aws/lambda_/function.py
+++ b/touchdown/aws/lambda_/function.py
@@ -155,7 +155,7 @@ class Apply(SimpleApply, Describe):
 
         # Sort on the Version and drop the last one. This should be the most
         # recent one - i.e. what $LATEST is pointing at.
-        versions.sort(key=lambda x: int(x['Version']))
+        versions = sorted(versions, key=lambda x: int(x['Version']))
         versions = versions[:-1]
 
         return versions

--- a/touchdown/aws/lambda_/function.py
+++ b/touchdown/aws/lambda_/function.py
@@ -51,7 +51,7 @@ class FunctionSerializer(serializers.Formatter):
         zf.close()
         return buf.getvalue()
 
-argument.String.register_adapter(types.FunctionType, lambda r: FunctionSerializer(r))
+argument.String.register_adapter(types.FunctionType, lambda r: FunctionSerializer(serializers.Const(r)))
 
 
 class Function(Resource):
@@ -174,7 +174,7 @@ class Apply(SimpleApply, Describe):
             hasher = hashlib.sha256(serialized['Code']['ZipFile'])
             digest = base64.b64encode(hasher.digest()).decode('utf-8')
             if self.object['CodeSha256'] != digest:
-                 update_code = True
+                update_code = True
 
         if update_code:
             yield self.generic_action(
@@ -229,7 +229,6 @@ class Apply(SimpleApply, Describe):
 
         for action in super(Apply, self).update_object():
             yield action
-
 
 
 class Destroy(SimpleDestroy, Describe):

--- a/touchdown/core/argument.py
+++ b/touchdown/core/argument.py
@@ -19,7 +19,7 @@ import netaddr
 import six
 
 from . import errors, serializers
-from .utils import force_str
+from .utils import force_bytes, force_str
 
 
 class Argument(object):
@@ -196,6 +196,38 @@ class String(Argument):
         if self.regex is not None and not re.match(self.regex, value):
             raise errors.InvalidParameter(
                 "Regex validation failed ({})".format(self.regex),
+            )
+
+        return value
+
+
+class Bytes(Argument):
+
+    """ Represents a collection of bytes """
+
+    serializer = serializers.Bytes()
+
+    min = None
+    max = None
+
+    def clean(self, instance, value):
+        if value is None:
+            return value
+
+        if not isinstance(value, six.binary_type):
+            raise errors.InvalidParameter("Value {!r} is not a bytes".format(value))
+
+        # Cast to native string type for this python version
+        value = force_bytes(value)
+
+        if self.min is not None and len(value) < self.min:
+            raise errors.InvalidParameter(
+                "Value should be at least {} bytes".format(self.min),
+            )
+
+        if self.max is not None and len(value) > self.max:
+            raise errors.InvalidParameter(
+                "Value should be at most {} bytes".format(self.max),
             )
 
         return value

--- a/touchdown/core/serializers.py
+++ b/touchdown/core/serializers.py
@@ -479,7 +479,7 @@ class Map(Dict):
         return d
 
     def pending(self, runner, object):
-        return any(maybe(v).pending(runner, v) for v in object.values()) 
+        return any(maybe(v).pending(runner, v) for v in object.values())
 
     def dependencies(self, object):
         return frozenset(itertools.chain(*tuple(c.dependencies(object) for c in object.values())))
@@ -498,7 +498,7 @@ class Resource(Dict):
     def should_ignore_field(self, object, field, value):
         arg = field.argument
         if not hasattr(arg, "field"):
-             return True
+            return True
         if not arg.empty_serializer and not field.present(object):
             if value is None:
                 return True

--- a/touchdown/core/serializers.py
+++ b/touchdown/core/serializers.py
@@ -55,8 +55,8 @@ class Serializer(object):
         rendered = self.render(runner, object)
         return diff.ValueDiff(value, rendered)
 
-    def pending(self):
-        return True
+    def pending(self, runner, obj):
+        return False
 
     def dependencies(self, object):
         return frozenset()
@@ -444,7 +444,7 @@ class Dict(Serializer):
         return d
 
     def pending(self, runner, object):
-        return self.inner.pending(runner, object)
+        return any(v.pending(runner, v) for v in self.kwargs.values())
 
     def dependencies(self, object):
         return frozenset(itertools.chain(*tuple(c.dependencies(object) for c in self.kwargs.values())))

--- a/touchdown/core/serializers.py
+++ b/touchdown/core/serializers.py
@@ -17,7 +17,7 @@ import json
 
 from six.moves import zip_longest
 from touchdown.core import diff, errors
-from touchdown.core.utils import force_str
+from touchdown.core.utils import force_bytes, force_str
 
 
 class FieldNotPresent(Exception):
@@ -328,6 +328,21 @@ class String(Formatter):
 
     def diff(self, runner, object, value):
         return super(String, self).diff(runner, object, None if value is None else str(value))
+
+
+class Bytes(Formatter):
+
+    def render(self, runner, object):
+        if object is None:
+            return None
+
+        try:
+            return force_bytes(self.inner.render(runner, object))
+        except ValueError:
+            return str(self.inner.render(runner, object))
+
+    def diff(self, runner, object, value):
+        return super(Bytes, self).diff(runner, object, None if value is None else str(value))
 
 
 class Integer(Formatter):

--- a/touchdown/provisioner/__init__.py
+++ b/touchdown/provisioner/__init__.py
@@ -16,7 +16,7 @@ from .provisioner import Provisioner, Target
 from .bash import Script
 from .fuselage import Bundle
 from .local import Local
-from .local_output import LocalOutput
+from .output import Output
 
 
 __all__ = [
@@ -26,5 +26,5 @@ __all__ = [
     "Script",
     "Bundle",
     "Local",
-    "LocalOutput",
+    "Output",
 ]

--- a/touchdown/provisioner/local.py
+++ b/touchdown/provisioner/local.py
@@ -39,6 +39,10 @@ class Connection(object):
         self.plan = plan
         self.resource = plan.resource
 
+    def get_path_contents(self, path):
+        with open(path) as fp:
+            return fp.read()
+
     def run_script(self, script, stdout=None, stderr=None):
         fd, script_name = tempfile.mkstemp()
         try:

--- a/touchdown/provisioner/local.py
+++ b/touchdown/provisioner/local.py
@@ -43,6 +43,10 @@ class Connection(object):
         with open(path) as fp:
             return fp.read()
 
+    def get_path_bytes(self, path):
+        with open(path, "rb") as fp:
+            return fp.read()
+
     def run_script(self, script, stdout=None, stderr=None):
         fd, script_name = tempfile.mkstemp()
         try:

--- a/touchdown/provisioner/local_output.py
+++ b/touchdown/provisioner/local_output.py
@@ -12,19 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .provisioner import Provisioner, Target
-from .bash import Script
-from .fuselage import Bundle
+from touchdown.core import argument, resource, serializers
+
 from .local import Local
-from .local_output import LocalOutput
 
 
-__all__ = [
-    "Provisioner",
-    "Step",
-    "Target",
-    "Script",
-    "Bundle",
-    "Local",
-    "LocalOutput",
-]
+class LocalOutput(resource.Resource):
+
+    resource_name = "local_output"
+
+    name = argument.String()
+
+    local = argument.Resource(Local)
+
+
+class LocalOutputAsString(serializers.Serializer):
+
+    def __init__(self, resource):
+        self.resource = resource
+
+    def render(self, runner, object):
+        with open(self.resource.name) as fp:
+            return fp.read()
+
+    def dependencies(self, object):
+        return frozenset((self.resource, ))
+
+
+argument.String.register_adapter(LocalOutput, lambda r: LocalOutputAsString(r))

--- a/touchdown/provisioner/output.py
+++ b/touchdown/provisioner/output.py
@@ -14,19 +14,19 @@
 
 from touchdown.core import argument, resource, serializers
 
-from .local import Local
+from .provisioner import Provisioner
 
 
-class LocalOutput(resource.Resource):
+class Output(resource.Resource):
 
-    resource_name = "local_output"
+    resource_name = "output"
 
     name = argument.String()
 
-    local = argument.Resource(Local)
+    provisioner = argument.Resource(Provisioner)
 
 
-class LocalOutputAsString(serializers.Serializer):
+class OutputAsString(serializers.Serializer):
 
     def __init__(self, resource):
         self.resource = resource
@@ -39,4 +39,4 @@ class LocalOutputAsString(serializers.Serializer):
         return frozenset((self.resource, ))
 
 
-argument.String.register_adapter(LocalOutput, lambda r: LocalOutputAsString(r))
+argument.String.register_adapter(Output, lambda r: OutputAsString(r))

--- a/touchdown/provisioner/output.py
+++ b/touchdown/provisioner/output.py
@@ -32,8 +32,9 @@ class OutputAsString(serializers.Serializer):
         self.resource = resource
 
     def render(self, runner, object):
-        with open(self.resource.name) as fp:
-            return fp.read()
+        service = runner.get_service(self.resource.provisioner.target, "describe")
+        client = service.get_client()
+        return client.get_path_contents(self.resource.name)
 
     def dependencies(self, object):
         return frozenset((self.resource, ))

--- a/touchdown/provisioner/output.py
+++ b/touchdown/provisioner/output.py
@@ -32,16 +32,17 @@ class OutputAsString(serializers.Serializer):
         self.resource = resource
 
     def render(self, runner, object):
-        # If this is serialized before the provisioner has done stuff then
-        # return a Pending object.
-        provisioner = runner.get_service(self.resource.provisioner, "apply")
-        if provisioner.object["Result"] == "Pending":
-            return serializers.Pending(self.resource.provisioner)
+        if self.pending(runner, object):
+            return serializers.Pending(self.resource)
 
         # Extract the contents from the file on the (potentially remote) target
         service = runner.get_service(self.resource.provisioner.target, "describe")
         client = service.get_client()
         return client.get_path_contents(self.resource.name)
+
+    def pending(self, runner, object):
+        provisioner = runner.get_service(self.resource.provisioner, "apply")
+        return provisioner.object["Result"] == "Pending"
 
     def dependencies(self, object):
         return frozenset((self.resource, ))

--- a/touchdown/provisioner/provisioner.py
+++ b/touchdown/provisioner/provisioner.py
@@ -45,10 +45,10 @@ class RunScript(action.Action):
         client = self.get_plan(self.resource.target).get_client()
         try:
             client.run_script(kwargs['script'])
-            self.object["Result"] = "Success"
+            self.plan.object["Result"] = "Success"
         except Exception as e:
-            self.object["Result"] = "Error"
-            self.object["ErrorMessage"] = str(e)
+            self.plan.object["Result"] = "Error"
+            self.plan.object["ErrorMessage"] = str(e)
             raise
 
 

--- a/touchdown/provisioner/provisioner.py
+++ b/touchdown/provisioner/provisioner.py
@@ -43,7 +43,13 @@ class RunScript(action.Action):
     def run(self):
         kwargs = serializers.Resource().render(self.runner, self.resource)
         client = self.get_plan(self.resource.target).get_client()
-        client.run_script(kwargs['script'])
+        try:
+            client.run_script(kwargs['script'])
+            self.object["Result"] = "Success"
+        except Exception as e:
+            self.object["Result"] = "Error"
+            self.object["ErrorMessage"] = str(e)
+            raise
 
 
 class Apply(plan.Plan):
@@ -52,5 +58,6 @@ class Apply(plan.Plan):
     resource = Provisioner
 
     def get_actions(self):
+        self.object = {"Result": "Pending"}
         if self.resource.target:
             yield RunScript(self)

--- a/touchdown/ssh/client.py
+++ b/touchdown/ssh/client.py
@@ -113,6 +113,15 @@ class Client(paramiko.SSHClient):
         finally:
             sftp.close()
 
+    def get_path_bytes(self, path):
+        sftp = self.open_sftp()
+        sftp.chdir(".")
+        try:
+            with sftp.file(path) as fp:
+                return fp.read()
+        finally:
+            sftp.close()
+
     def run_script(self, script, sudo=True):
         sftp = self.open_sftp()
         sftp.chdir(".")

--- a/touchdown/ssh/client.py
+++ b/touchdown/ssh/client.py
@@ -104,6 +104,15 @@ class Client(paramiko.SSHClient):
         finally:
             channel.close()
 
+    def get_path_contents(self, path):
+        sftp = self.open_sftp()
+        sftp.chdir(".")
+        try:
+            with sftp.file(path) as fp:
+                return fp.read()
+        finally:
+            sftp.close()
+
     def run_script(self, script, sudo=True):
         sftp = self.open_sftp()
         sftp.chdir(".")

--- a/touchdown/tests/test_aws_lambda_function.py
+++ b/touchdown/tests/test_aws_lambda_function.py
@@ -1,0 +1,95 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from botocore.stub import Stubber
+
+from touchdown import frontends
+from touchdown.core import goals, workspace
+from touchdown.core.map import SerialMap
+
+
+def dummy_function(a, b):
+    """ This is a dummy function to test the serializers """
+    pass
+
+
+class TestLambdaFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.workspace = workspace.Workspace()
+        self.aws = self.workspace.add_aws(access_key_id='dummy', secret_access_key='dummy', region='eu-west-1')
+        self.goal = goals.create(
+            "apply",
+            self.workspace,
+            frontends.ConsoleFrontend(interactive=False),
+            map=SerialMap
+        )
+
+    def test_get_all_unaliased_versions(self):
+        fn = self.aws.add_lambda_function(
+            name="myfunction",
+            role=self.aws.get_role(name="myrole"),
+            handler="mymodule.myfunction",
+            code=dummy_function,
+        )
+        apply_service = self.goal.get_service(fn, "apply")
+        with Stubber(apply_service.client) as stub:
+            stub.add_response(
+                'list_versions_by_function',
+                service_response={
+                    'Versions': [
+                        {
+                            'FunctionName': 'myfunction',
+                            'Version': '$LATEST',
+                        },
+                        {
+                            'FunctionName': 'myfunction',
+                            'Version': '1',
+                        },
+                        {
+                            'FunctionName': 'myfunction',
+                            'Version': '2',
+                        },
+                        {
+                            'FunctionName': 'myfunction',
+                            'Version': '3',
+                        },
+                    ],
+                },
+                expected_params={
+                    'FunctionName': 'myfunction'
+                },
+            )
+            stub.add_response(
+                'list_aliases',
+                service_response={
+                    'Aliases': [
+                        {
+                            'Name': 'stable',
+                            'FunctionVersion': '1',
+                        }
+                    ]
+                },
+                expected_params={
+                    'FunctionName': 'myfunction'
+                },
+            )
+            versions = apply_service.get_all_unaliased_versions()
+
+        self.assertEqual(versions, [{
+            "FunctionName": "myfunction",
+            "Version": "2",
+        }])

--- a/touchdown/tests/test_aws_lambda_function.py
+++ b/touchdown/tests/test_aws_lambda_function.py
@@ -113,6 +113,13 @@ class TestLambdaFunction(unittest.TestCase):
             "FunctionName": "myfunction",
             "CodeSha256": "QWfDvEHUTP0EFEWOjRkXeP733yzB67f9ViAssuXF6/8="
         }
+
+        # FIXME: Zip's produced on Windows have stables hashes (zipping the
+        # same thing repeatedly yields the same result)
+        # But the hashes are different from posix zips.
+        if sys.platform == "win32":
+            self.apply_service.object['CodeSha256'] = 'kI3Czz0As/qAcnAq0JzbVG/NzSPUS4khRcbHuKivW0k='
+
         with Stubber(self.apply_service.client):
             for action in self.apply_service.update_code_by_zip():
                 action.run()

--- a/touchdown/tests/test_aws_lambda_function.py
+++ b/touchdown/tests/test_aws_lambda_function.py
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import os
+import shutil
+import sys
+import tempfile
 import unittest
 
+import pytest
 from botocore.stub import ANY, Stubber
 
 from touchdown import frontends
@@ -164,3 +170,99 @@ class TestLambdaFunction(unittest.TestCase):
             )
             for action in self.apply_service.update_code_by_s3():
                 action.run()
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="does not run on windows")
+class TestLambdaFunctionIntegration(unittest.TestCase):
+
+    def setUp(self):
+        self.workspace = workspace.Workspace()
+        self.aws = self.workspace.add_aws(access_key_id='dummy', secret_access_key='dummy', region='eu-west-1')
+        self.goal = goals.create(
+            "apply",
+            self.workspace,
+            frontends.ConsoleFrontend(interactive=False),
+            map=SerialMap
+        )
+        self.test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.test_dir)
+
+    def test_build_a_zip(self):
+        bundle = self.workspace.add_fuselage_bundle(
+            target=self.workspace.add_local()
+        )
+        bundle.add_execute(command="zip {} {}".format(
+            os.path.join(self.test_dir, "lambda.zip"),
+            __file__,
+        ))
+        self.fn = self.aws.add_lambda_function(
+            name="myfunction",
+            role=self.aws.get_role(name="myrole"),
+            handler="mymodule.myfunction",
+            code=bundle.add_output(name=os.path.join(self.test_dir, "lambda.zip")),
+        )
+
+        role_service = self.goal.get_service(self.fn.role, "describe")
+        fn_service = self.goal.get_service(self.fn, "apply")
+
+        role_stubber = Stubber(role_service.client)
+        role_stubber.add_response(
+            'list_roles',
+            service_response={
+                'Roles': [{
+                    'RoleName': 'myrole',
+                    'Path': '/iam/myrole',
+                    'RoleId': '1234567890123456',
+                    'Arn': '12345678901234567890',
+                    'CreateDate': datetime.datetime.now(),
+                }],
+            },
+            expected_params={},
+        )
+
+        fn_stubber = Stubber(fn_service.client)
+        fn_stubber.add_response(
+            'get_function_configuration',
+            service_response={
+                'FunctionName': 'myfunction',
+                'CodeSha256': '',
+                'Handler': 'mymodule.myfunction',
+                'Role': '12345678901234567890',
+            },
+            expected_params={
+                'FunctionName': 'myfunction',
+            },
+        )
+        fn_stubber.add_response(
+            'list_versions_by_function',
+            service_response={
+                'Versions': [],
+            },
+            expected_params={
+                'FunctionName': 'myfunction',
+            },
+        )
+        fn_stubber.add_response(
+            'list_aliases',
+            service_response={
+                'Aliases': [],
+            },
+            expected_params={
+                'FunctionName': 'myfunction',
+            },
+        )
+        fn_stubber.add_response(
+            'update_function_code',
+            service_response={
+                'FunctionName': 'myfunction',
+            },
+            expected_params={
+                'FunctionName': 'myfunction',
+                'ZipFile': ANY,
+                'Publish': True,
+            },
+        )
+
+        with role_stubber:
+            with fn_stubber:
+                self.goal.execute()

--- a/touchdown/tests/test_aws_s3_bucket.py
+++ b/touchdown/tests/test_aws_s3_bucket.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import mock
 
 from botocore.stub import Stubber
 
@@ -41,17 +40,13 @@ class TestBucketDescribe(unittest.TestCase):
         bucket = self.aws.add_bucket(name="mybucket")
         desc = self.goal.get_service(bucket, "describe")
 
-        desc.client.meta.events.unregister("after-call.s3.GetBucketLocation")
-
         stub = Stubber(desc.client)
 
-        # See https://github.com/boto/botocore/pull/937
-        desc.client.get_bucket_location = mock.Mock(return_value={"LocationConstraint": "eu-central-1"})
-        # stub.add_response(
-        #     'get_bucket_location',
-        #     {'LocationConstraint': 'eu-central-1'},
-        #     {'Bucket': 'mybucket'},
-        # )
+        stub.add_response(
+            'get_bucket_location',
+            {'LocationConstraint': 'eu-central-1'},
+            {'Bucket': 'mybucket'},
+        )
         stub.add_response(
             'get_bucket_cors',
             {'CORSRules': []},

--- a/touchdown/tests/test_provisioner.py
+++ b/touchdown/tests/test_provisioner.py
@@ -34,6 +34,7 @@ class TestCase(unittest.TestCase):
             map=SerialMap
         )
         self.apply_runner.execute()
+        return self.apply_runner
 
     def test_destroy(self):
         self.destroy_runner = goals.create(
@@ -86,3 +87,23 @@ class TestCase(unittest.TestCase):
         )
         self.apply()
         self.assertFalse(os.path.exists(fp.name))
+
+    def test_output(self):
+        with tempfile.NamedTemporaryFile(delete=True) as fp:
+            fp.close()
+
+            bundle = self.workspace.add_fuselage_bundle(
+                target=self.workspace.add_local(),
+            )
+            bundle.add_file(
+                name=fp.name,
+                contents=serializers.Const("hello"),
+            )
+
+            output = bundle.target.add_local_output(name=fp.name)
+            echo = self.workspace.add_echo(text=output)
+
+            self.assertEqual(
+                self.apply().get_service(echo, "apply").object["Text"],
+                "hello",
+            )

--- a/touchdown/tests/test_provisioner.py
+++ b/touchdown/tests/test_provisioner.py
@@ -100,7 +100,7 @@ class TestCase(unittest.TestCase):
                 contents=serializers.Const("hello"),
             )
 
-            output = bundle.target.add_local_output(name=fp.name)
+            output = bundle.add_output(name=fp.name)
             echo = self.workspace.add_echo(text=output)
 
             self.assertEqual(


### PR DESCRIPTION
The goal here is to be able to use a local fuselage bundle to generate a zip which can be uploaded to AWS Lambda.

This means certain files need to be marked as generated by a bundle:

    bundle = workspace.add_fuselage_bundle(target=workspace.add_local())
    bundle.add_execute(command="make mylambda.zip")
    mylambdazip = bundle.add_output(name="mylambda.zip")

And be able to pass those outputs to to anything that accepts a string:

    aws.add_lambda_function(
        name='mylambdafunction',
        role=aws.get_role(name='mylambdiamarole'),
        handler='mymodule.myfunction',
        code=mylambdazip,
    )