### PR TITLE
Add port forwarding over SSH

### DIFF
--- a/touchdown/aws/rds/database.py
+++ b/touchdown/aws/rds/database.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from touchdown.core import argument, serializers
+from touchdown.core import argument, output, serializers
 from touchdown.core.errors import InvalidParameter
 from touchdown.core.plan import Plan, Present
 from touchdown.core.resource import Resource
@@ -59,6 +59,8 @@ class Database(Resource):
     apply_immediately = argument.Boolean(field="ApplyImmediately", aws_create=False)
     # tags = argument.Dict()
     account = argument.Resource(BaseAccount)
+
+    endpoint_address = output.Output(serializers.Property("Endpoint.Address"))
 
     def clean_storage_encrypted(self, value):
         if not value:

--- a/touchdown/core/main.py
+++ b/touchdown/core/main.py
@@ -36,6 +36,8 @@ class SubCommand(object):
         args = []
         for arg in argspec.args[1:]:
             args.append(getattr(namespace, arg))
+        if argspec.varargs:
+            args.extend(getattr(namespace, argspec.varargs))
         kwargs = {}
         for k, v in namespace._get_kwargs():
             if k not in argspec.args and argspec.keywords:

--- a/touchdown/core/output.py
+++ b/touchdown/core/output.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Isotoma Limited
+# Copyright 2016 Isotoma Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .client import Client, private_key_from_string
-from .connection import Connection, Instance
-from .portfwd import PortForward
-
-from . import terminal  # noqa
+from . import errors, serializers
 
 
-__all__ = [
-    "Client",
-    "Connection",
-    "Instance",
-    "PortForward",
-    "private_key_from_string",
-]
+class Output(object):
+
+    def __init__(self, serializer):
+        self.serializer = serializer
+
+    def __set__(self, instance, value):
+        raise errors.Error("This attribute is read-only!")
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return serializers.Context(
+            serializers.Const(instance),
+            self.serializer,
+        )

--- a/touchdown/goals/__init__.py
+++ b/touchdown/goals/__init__.py
@@ -19,6 +19,7 @@ from .dot import Dot
 from .edit import Edit
 from .get import Get
 from .get_signin_url import GetSigninUrl
+from .portfwd import PortForward
 from .refresh import Refresh
 from .rollback import Rollback
 from .scp import Scp
@@ -36,6 +37,7 @@ __all__ = [
     "Edit",
     "Get",
     "GetSigninUrl",
+    "PortForward",
     "Refresh",
     "Rollback",
     "Set",

--- a/touchdown/goals/portfwd.py
+++ b/touchdown/goals/portfwd.py
@@ -1,0 +1,98 @@
+# Copyright 2015 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import errno
+import select
+
+from touchdown.core import errors
+from touchdown.core.goals import Goal, register
+
+
+def _eintr_retry(func, *args):
+    while True:
+        try:
+            return func(*args)
+        except (OSError, select.error) as e:
+            if e.args[0] != errno.EINTR:
+                raise
+
+
+class PortForward(Goal):
+
+    """ Forward remote ports to local computer """
+
+    name = "portfwd"
+    mutator = False
+
+    def get_plan_class(self, resource):
+        plan_class = resource.meta.get_plan("portfwd")
+        if not plan_class:
+            plan_class = resource.meta.get_plan("describe")
+        if not plan_class:
+            plan_class = resource.meta.get_plan("null")
+        return plan_class
+
+    @classmethod
+    def setup_argparse(cls, parser):
+        parser.add_argument(
+            dest="ports",
+            metavar="PORT",
+            nargs="+",
+            type=str,
+            help="Remote port to forward to local port (e.g. db=8093)",
+        )
+
+    def get_services(self, *ports):
+        services = self.collect_as_dict("portfwd")
+        if not services:
+            raise errors.Error("No port-forwardable resources are defined")
+
+        for p in ports:
+            if "=" not in p:
+                raise errors.Error("Invalid port specification '{}'".format(p))
+
+            service, local_port = p.split("=", 1)
+
+            if service not in services:
+                raise errors.Error("Not a valid service: '{}'. Must be one of: {}".format(
+                    service,
+                    ", ".join(sorted(services.keys())),
+                ))
+
+            try:
+                local_port = int(local_port)
+            except ValueError:
+                raise errors.Error("Not a valid port number: '{}'".format(p))
+
+            yield (services[service], local_port)
+
+    def process_incoming_forever(self, servers):
+        # This is broadly the same as a TCPServer.serve_forever, but we do it
+        # for multiple ports/protocols at once
+        try:
+            while True:
+                r, w, e = _eintr_retry(select.select, servers, [], [], 0.5)
+                for server in r:
+                    server._handle_request_noblock()
+        except KeyboardInterrupt:
+            self.ui.echo("Interupted. Exiting...")
+
+    def execute(self, *ports):
+        mappings = self.get_services(ports)
+        servers = [s.start(lp) for s, lp in mappings]
+
+        self.ui.echo("All requested port forwards started. Waiting for connections...")
+        self.process_incoming_forever(servers)
+
+register(PortForward)

--- a/touchdown/ssh/portfwd.py
+++ b/touchdown/ssh/portfwd.py
@@ -1,0 +1,117 @@
+# Copyright 2015 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import select
+
+from touchdown.core import argument, errors, plan, resource, serializers
+from touchdown.ssh.connection import Connection
+
+try:
+    import SocketServer
+except ImportError:
+    import socketserver as SocketServer
+
+
+class PortForward(resource.Resource):
+
+    resource_name = "port_forward"
+
+    name = argument.String()
+
+    host = argument.String(field='host')
+    port = argument.Integer(field='port')
+
+    via = argument.Resource(Connection)
+
+
+class ForwardServer (SocketServer.ThreadingTCPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+class Handler (SocketServer.BaseRequestHandler):
+
+    def handle(self):
+        try:
+            chan = self.ssh_transport.open_channel(
+                'direct-tcpip',
+                (self.chain_host, self.chain_port),
+                self.request.getpeername(),
+            )
+        except Exception as e:
+            raise errors.Error(
+                "Failed to connect to {}:{} ({})".format(
+                    self.chain_host,
+                    self.chain_port,
+                    repr(e),
+                )
+            )
+
+        if chan is None:
+            raise errors.Error(
+                "Connect to {}:{} rejected by remote SSH server".format(
+                    self.chain_host,
+                    self.chain_port,
+                ),
+            )
+
+        self.plan.echo("Tunnel {} -> {} -> {} established".format(
+            self.request.getpeername(),
+            chan.getpeername(),
+            (self.chain_host, self.chain_port),
+        ))
+
+        while True:
+            r, w, x = select.select([self.request, chan], [], [])
+            if self.request in r:
+                data = self.request.recv(1024)
+                if len(data) == 0:
+                    break
+                chan.send(data)
+            if chan in r:
+                data = chan.recv(1024)
+                if len(data) == 0:
+                    break
+                self.request.send(data)
+
+        peername = self.request.getpeername()
+        chan.close()
+        self.request.close()
+        self.plan.echo('Tunnel closed from {}'.format(peername))
+
+
+class ConnectionPlan(plan.Plan):
+
+    name = "portfwd"
+    resource = PortForward
+
+    def start(self, local_port):
+        via = self.runner.get_service(self.resource.via, "describe")
+        transport = via.get_client().get_transport()
+
+        params = serializers.Resource().render(self.runner, self.resource)
+
+        class SubHandler (Handler):
+            chain_host = params['host']
+            chain_port = params['port']
+            ssh_transport = transport
+            plan = self
+
+        server = ForwardServer(('', local_port), SubHandler)
+        self.echo("Opening port *:{} -> {}:{}".format(
+            server.server_address[1],
+            params['host'],
+            params['port'],
+        ))
+        return server


### PR DESCRIPTION
This lets you define well known ports within your infrastructure and then access them locally using port forwarding. For example, suppose you have an EC2 instance that runs Solr and you want to access it locally. And that it is on a private IP so you have to connect to your autoscaling group first. You might have something like this:

    connection = self.workspace.add_ssh_connection(
        name="solr",
        instance=solr_ec2_instance,
        proxy=www_ssh_connection,
        username="ubuntu",
        private_key=self.read(os.path.join("etc/keys", self.environment + ".pem.gpg"))
    )

    connection.add_port_forward(
        name="solr",
        host="localhost",
        port=8983,
    )

When you run `touchdown portfwd solr=8000` touchdown will ssh into the `solr_ec2_instance` (bouncing off the SSH connection `www_ssh_connection`) and then connect port `8000` on your local computer to port `8983` on `localhost` on the solr ec2 instance.