### PR TITLE
AWS: Pin API versions used when deploying

### DIFF
--- a/touchdown/aws/acm/certificate.py
+++ b/touchdown/aws/acm/certificate.py
@@ -49,6 +49,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Certificate
     service_name = "acm"
+    api_version = '2015-12-08'
     describe_action = "list_certificates"
     describe_envelope = "CertificateSummaryList"
     describe_filters = {}

--- a/touchdown/aws/apigateway/deployment.py
+++ b/touchdown/aws/apigateway/deployment.py
@@ -42,6 +42,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Deployment
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_deployments"
     describe_envelope = "items"
     key = 'id'

--- a/touchdown/aws/apigateway/integration.py
+++ b/touchdown/aws/apigateway/integration.py
@@ -49,6 +49,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Integration
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_integration"
     describe_notfound_exception = "NotFoundException"
     describe_envelope = "[@]"

--- a/touchdown/aws/apigateway/integration_response.py
+++ b/touchdown/aws/apigateway/integration_response.py
@@ -41,6 +41,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = IntegrationResponse
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_integration_response"
     describe_notfound_exception = "NotFoundException"
     describe_envelope = "[@]"

--- a/touchdown/aws/apigateway/method.py
+++ b/touchdown/aws/apigateway/method.py
@@ -40,6 +40,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Method
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_method"
     describe_notfound_exception = "NotFoundException"
     describe_envelope = "[@]"

--- a/touchdown/aws/apigateway/method_response.py
+++ b/touchdown/aws/apigateway/method_response.py
@@ -39,6 +39,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = MethodResponse
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_method_response"
     describe_notfound_exception = "NotFoundException"
     describe_envelope = "[@]"

--- a/touchdown/aws/apigateway/model.py
+++ b/touchdown/aws/apigateway/model.py
@@ -38,6 +38,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Model
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_models"
     describe_envelope = "items"
     key = 'id'

--- a/touchdown/aws/apigateway/resource.py
+++ b/touchdown/aws/apigateway/resource.py
@@ -39,6 +39,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Resource
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_resources"
     describe_envelope = "items"
     key = 'id'

--- a/touchdown/aws/apigateway/rest_api.py
+++ b/touchdown/aws/apigateway/rest_api.py
@@ -34,6 +34,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = RestApi
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_rest_apis"
     describe_envelope = "items"
     key = 'id'

--- a/touchdown/aws/apigateway/stage.py
+++ b/touchdown/aws/apigateway/stage.py
@@ -41,6 +41,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Stage
     service_name = 'apigateway'
+    api_version = '2015-07-09'
     describe_action = "get_stages"
     describe_envelope = "item"  # This is not a typo
     key = 'id'

--- a/touchdown/aws/cloudfront/streaming_distribution.py
+++ b/touchdown/aws/cloudfront/streaming_distribution.py
@@ -91,6 +91,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = StreamingDistribution
     service_name = 'cloudfront'
+    api_version = '2016-01-28'
     describe_filters = {}
     describe_action = "list_streaming_distributions"
     describe_envelope = 'StreamingDistributionList.Items'

--- a/touchdown/aws/cloudtrail/trail.py
+++ b/touchdown/aws/cloudtrail/trail.py
@@ -44,6 +44,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Trail
     service_name = 'cloudtrail'
+    api_version = '2013-11-01'
     describe_action = "describe_trails"
     describe_envelope = "trailList"
     key = 'Name'

--- a/touchdown/aws/cloudwatch/alarm.py
+++ b/touchdown/aws/cloudwatch/alarm.py
@@ -100,6 +100,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Alarm
     service_name = 'cloudwatch'
+    api_version = '2010-08-01'
     describe_action = "describe_alarms"
     describe_envelope = "MetricAlarms"
     key = 'AlarmName'

--- a/touchdown/aws/cloudwatch/metric.py
+++ b/touchdown/aws/cloudwatch/metric.py
@@ -34,6 +34,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Metric
     service_name = 'cloudwatch'
+    api_version = '2010-08-01'
     describe_action = "list_metrics"
     describe_envelope = "Metrics"
     key = 'MetricName'

--- a/touchdown/aws/ec2/ami.py
+++ b/touchdown/aws/ec2/ami.py
@@ -192,6 +192,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Image
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_images"
     describe_envelope = "Images"
     key = 'ImageId'

--- a/touchdown/aws/ec2/ami_copy.py
+++ b/touchdown/aws/ec2/ami_copy.py
@@ -47,6 +47,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = ImageCopy
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_images"
     describe_envelope = "Images"
     key = 'ImageId'

--- a/touchdown/aws/ec2/auto_scaling_group.py
+++ b/touchdown/aws/ec2/auto_scaling_group.py
@@ -220,6 +220,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = AutoScalingGroup
     service_name = 'autoscaling'
+    api_version = '2011-01-01'
     describe_action = "describe_auto_scaling_groups"
     describe_envelope = "AutoScalingGroups"
     key = 'AutoScalingGroupName'

--- a/touchdown/aws/ec2/auto_scaling_policy.py
+++ b/touchdown/aws/ec2/auto_scaling_policy.py
@@ -44,6 +44,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Policy
     service_name = 'autoscaling'
+    api_version = '2011-01-01'
     describe_action = "describe_policies"
     describe_envelope = "ScalingPolicies"
     key = 'PolicyName'

--- a/touchdown/aws/ec2/instance.py
+++ b/touchdown/aws/ec2/instance.py
@@ -79,6 +79,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Instance
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_instances"
     describe_envelope = "Reservations[].Instances[]"
     key = 'InstanceId'

--- a/touchdown/aws/ec2/keypair.py
+++ b/touchdown/aws/ec2/keypair.py
@@ -64,6 +64,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = KeyPair
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_key_pairs"
     describe_envelope = "KeyPairs"
     describe_notfound_exception = "InvalidKeyPair.NotFound"

--- a/touchdown/aws/ec2/launch_configuration.py
+++ b/touchdown/aws/ec2/launch_configuration.py
@@ -85,6 +85,7 @@ class Describe(ReplacementDescribe, Plan):
 
     resource = LaunchConfiguration
     service_name = 'autoscaling'
+    api_version = '2011-01-01'
     describe_action = "describe_launch_configurations"
     describe_envelope = "LaunchConfigurations"
     describe_filters = {}

--- a/touchdown/aws/ec2/volume.py
+++ b/touchdown/aws/ec2/volume.py
@@ -41,6 +41,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Volume
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = 'describe_volumes'
     describe_notfound_exception = 'InvalidVolume.NotFound'
     describe_envelope = 'Volumes'

--- a/touchdown/aws/ec2/volume_attachment.py
+++ b/touchdown/aws/ec2/volume_attachment.py
@@ -38,6 +38,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = VolumeAttachment
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = 'describe_volumes'
     describe_envelope = 'Volumes'
     key = 'VolumeId'

--- a/touchdown/aws/elasticache/cache.py
+++ b/touchdown/aws/elasticache/cache.py
@@ -54,6 +54,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = CacheCluster
     service_name = 'elasticache'
+    api_version = '2015-02-02'
     describe_action = "describe_cache_clusters"
     describe_notfound_exception = "CacheClusterNotFound"
     describe_envelope = "CacheClusters"

--- a/touchdown/aws/elasticache/replication_group.py
+++ b/touchdown/aws/elasticache/replication_group.py
@@ -35,6 +35,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = ReplicationGroup
     service_name = 'elasticache'
+    api_version = '2015-02-02'
     describe_action = "describe_replication_groups"
     describe_envelope = "ReplicationGroups"
     describe_notfound_exception = "ReplicationGroupNotFoundFault"

--- a/touchdown/aws/elasticache/subnet_group.py
+++ b/touchdown/aws/elasticache/subnet_group.py
@@ -37,6 +37,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = SubnetGroup
     service_name = 'elasticache'
+    api_version = '2015-02-02'
     describe_action = "describe_cache_subnet_groups"
     describe_envelope = "CacheSubnetGroups"
     describe_notfound_exception = "CacheSubnetGroupNotFoundFault"

--- a/touchdown/aws/elastictranscoder/pipeline.py
+++ b/touchdown/aws/elastictranscoder/pipeline.py
@@ -76,6 +76,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Pipeline
     service_name = 'elastictranscoder'
+    api_version = '2012-09-25'
     describe_action = "list_pipelines"
     describe_envelope = "Pipelines"
     describe_filters = {}

--- a/touchdown/aws/elb/load_balancer.py
+++ b/touchdown/aws/elb/load_balancer.py
@@ -124,6 +124,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = LoadBalancer
     service_name = 'elb'
+    api_version = '2012-06-01'
     describe_action = "describe_load_balancers"
     describe_envelope = "LoadBalancerDescriptions"
     describe_notfound_exception = "LoadBalancerNotFound"

--- a/touchdown/aws/events/rule.py
+++ b/touchdown/aws/events/rule.py
@@ -80,6 +80,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = EventRule
     service_name = 'events'
+    api_version = '2015-10-07'
     describe_action = "list_rules"
     describe_envelope = "Rules"
     key = 'Name'

--- a/touchdown/aws/iam/instance_profile.py
+++ b/touchdown/aws/iam/instance_profile.py
@@ -35,6 +35,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = InstanceProfile
     service_name = 'iam'
+    api_version = '2010-05-08'
     describe_action = "list_instance_profiles"
     describe_envelope = "InstanceProfiles"
     describe_filters = {}

--- a/touchdown/aws/iam/role.py
+++ b/touchdown/aws/iam/role.py
@@ -61,6 +61,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Role
     service_name = 'iam'
+    api_version = '2010-05-08'
     describe_action = "list_roles"
     describe_envelope = "Roles"
     describe_filters = {}

--- a/touchdown/aws/iam/server_certificate.py
+++ b/touchdown/aws/iam/server_certificate.py
@@ -124,6 +124,7 @@ class Describe(ReplacementDescribe, Plan):
 
     resource = ServerCertificate
     service_name = 'iam'
+    api_version = '2010-05-08'
     describe_action = "list_server_certificates"
     describe_envelope = "ServerCertificateMetadataList"
     describe_filters = {}

--- a/touchdown/aws/kms/alias.py
+++ b/touchdown/aws/kms/alias.py
@@ -35,6 +35,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Alias
     service_name = 'kms'
+    api_version = '2014-11-01'
     describe_action = "list_aliases"
     describe_envelope = "Aliases"
     describe_filters = {}

--- a/touchdown/aws/kms/grant.py
+++ b/touchdown/aws/kms/grant.py
@@ -57,6 +57,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Grant
     service_name = 'kms'
+    api_version = '2014-11-01'
     describe_action = "list_grants"
     describe_envelope = "Grants"
     describe_filters = {}

--- a/touchdown/aws/kms/key.py
+++ b/touchdown/aws/kms/key.py
@@ -37,6 +37,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Key
     service_name = 'kms'
+    api_version = '2014-11-01'
     describe_action = "list_keys"
     describe_envelope = "Keys"
     describe_filters = {}

--- a/touchdown/aws/lambda_/function.py
+++ b/touchdown/aws/lambda_/function.py
@@ -139,6 +139,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Function
     service_name = 'lambda'
+    api_version = '2015-03-31'
     describe_action = "get_function_configuration"
     describe_notfound_exception = "ResourceNotFoundException"
     describe_envelope = "[@]"

--- a/touchdown/aws/lambda_/permission.py
+++ b/touchdown/aws/lambda_/permission.py
@@ -42,6 +42,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Permission
     service_name = 'lambda'
+    api_version = '2015-03-31'
     describe_action = "get_policy"
     describe_notfound_exception = "ResourceNotFoundException"
     describe_envelope = "[@]"

--- a/touchdown/aws/logs/filter.py
+++ b/touchdown/aws/logs/filter.py
@@ -48,6 +48,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Filter
     service_name = 'logs'
+    api_version = '2014-03-28'
     describe_action = 'describe_metric_filters'
     describe_notfound_exception = 'ResourceNotFoundException'
     describe_envelope = "metricFilters"

--- a/touchdown/aws/logs/group.py
+++ b/touchdown/aws/logs/group.py
@@ -39,6 +39,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = LogGroup
     service_name = 'logs'
+    api_version = '2014-03-28'
     describe_action = 'describe_log_groups'
     describe_envelope = "logGroups"
     key = "logGroupName"

--- a/touchdown/aws/password_policy.py
+++ b/touchdown/aws/password_policy.py
@@ -43,6 +43,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = PasswordPolicy
     service_name = 'iam'
+    api_version = '2010-05-08'
     describe_action = 'get_account_password_policy'
     describe_notfound_exception = 'NoSuchEntity'
     describe_envelope = '[PasswordPolicy]'

--- a/touchdown/aws/rds/database.py
+++ b/touchdown/aws/rds/database.py
@@ -86,6 +86,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Database
     service_name = 'rds'
+    api_version = '2014-10-31'
     describe_action = "describe_db_instances"
     describe_notfound_exception = "DBInstanceNotFound"
     describe_envelope = "DBInstances"

--- a/touchdown/aws/rds/rollback.py
+++ b/touchdown/aws/rds/rollback.py
@@ -40,6 +40,7 @@ class Plan(common.SimplePlan, plan.Plan):
     name = "rollback"
     resource = Database
     service_name = "rds"
+    api_version = '2014-10-31'
 
     def get_database(self, name):
         try:

--- a/touchdown/aws/rds/snapshot.py
+++ b/touchdown/aws/rds/snapshot.py
@@ -24,6 +24,7 @@ class Plan(common.SimplePlan, plan.Plan):
     name = "snapshot"
     resource = Database
     service_name = "rds"
+    api_version = '2014-10-31'
 
     def db_exists(self, name):
         try:

--- a/touchdown/aws/rds/subnet_group.py
+++ b/touchdown/aws/rds/subnet_group.py
@@ -37,6 +37,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = SubnetGroup
     service_name = 'rds'
+    api_version = '2014-10-31'
     describe_action = "describe_db_subnet_groups"
     describe_notfound_exception = "DBSubnetGroupNotFoundFault"
     describe_envelope = "DBSubnetGroups"

--- a/touchdown/aws/route53/zone.py
+++ b/touchdown/aws/route53/zone.py
@@ -98,6 +98,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = HostedZone
     service_name = 'route53'
+    api_version = '2013-04-01'
     describe_action = "list_hosted_zones"
     describe_envelope = "HostedZones"
     describe_filters = {}

--- a/touchdown/aws/s3/bucket.py
+++ b/touchdown/aws/s3/bucket.py
@@ -96,6 +96,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Bucket
     service_name = 's3'
+    api_version = '2006-03-01'
     describe_action = "list_buckets"
     describe_envelope = "Buckets"
     describe_filters = {}

--- a/touchdown/aws/s3/file.py
+++ b/touchdown/aws/s3/file.py
@@ -42,6 +42,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = File
     service_name = 's3'
+    api_version = '2006-03-01'
     describe_action = "list_objects"
     describe_envelope = "Contents"
     key = 'Name'

--- a/touchdown/aws/s3/folder.py
+++ b/touchdown/aws/s3/folder.py
@@ -44,6 +44,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Folder
     service_name = 's3'
+    api_version = '2006-03-01'
     key = 'Name'
     describe_action = None
 

--- a/touchdown/aws/sns/topic.py
+++ b/touchdown/aws/sns/topic.py
@@ -45,6 +45,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Topic
     service_name = 'sns'
+    api_version = '2010-03-31'
     describe_action = "list_topics"
     describe_envelope = "Topics"
     describe_filters = {}

--- a/touchdown/aws/sqs/queue.py
+++ b/touchdown/aws/sqs/queue.py
@@ -65,6 +65,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Queue
     service_name = 'sqs'
+    api_version = '2012-11-05'
     describe_action = 'get_queue_url'
     describe_envelope = "[@]"
     describe_notfound_exception = "AWS.SimpleQueueService.NonExistentQueue"

--- a/touchdown/aws/vpc/customer_gateway.py
+++ b/touchdown/aws/vpc/customer_gateway.py
@@ -36,6 +36,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = CustomerGateway
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_customer_gateways"
     describe_envelope = "CustomerGateways"
     key = "CustomerGatewayId"

--- a/touchdown/aws/vpc/elastic_ip.py
+++ b/touchdown/aws/vpc/elastic_ip.py
@@ -36,6 +36,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = ElasticIp
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_addresses"
     describe_envelope = "Addresses"
     key = "PublicIp"

--- a/touchdown/aws/vpc/internet_gateway.py
+++ b/touchdown/aws/vpc/internet_gateway.py
@@ -33,6 +33,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = InternetGateway
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_internet_gateways"
     describe_envelope = "InternetGateways"
     key = "InternetGatewayId"

--- a/touchdown/aws/vpc/nat_gateway.py
+++ b/touchdown/aws/vpc/nat_gateway.py
@@ -44,6 +44,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = NatGateway
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_nat_gateways"
     describe_envelope = "NatGateways"
     key = "NatGatewayId"

--- a/touchdown/aws/vpc/network_acl.py
+++ b/touchdown/aws/vpc/network_acl.py
@@ -127,6 +127,7 @@ class Describe(ReplacementDescribe, Plan):
 
     resource = NetworkACL
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_network_acls"
     describe_envelope = "NetworkAcls"
     key = 'NetworkAclId'

--- a/touchdown/aws/vpc/route_table.py
+++ b/touchdown/aws/vpc/route_table.py
@@ -61,6 +61,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = RouteTable
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_route_tables"
     describe_envelope = "RouteTables"
     key = "RouteTableId"

--- a/touchdown/aws/vpc/security_group.py
+++ b/touchdown/aws/vpc/security_group.py
@@ -115,6 +115,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = SecurityGroup
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_security_groups"
     describe_envelope = "SecurityGroups"
     key = 'GroupId'

--- a/touchdown/aws/vpc/subnet.py
+++ b/touchdown/aws/vpc/subnet.py
@@ -46,6 +46,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = Subnet
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_subnets"
     describe_envelope = "Subnets"
     key = 'SubnetId'

--- a/touchdown/aws/vpc/vpc.py
+++ b/touchdown/aws/vpc/vpc.py
@@ -37,6 +37,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = VPC
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_vpcs"
     describe_envelope = "Vpcs"
     key = 'VpcId'

--- a/touchdown/aws/vpc/vpn_connection.py
+++ b/touchdown/aws/vpc/vpn_connection.py
@@ -48,6 +48,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = VpnConnection
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_vpn_connections"
     describe_envelope = "VpnConnections"
     key = "VpnConnectionId"

--- a/touchdown/aws/vpc/vpn_gateway.py
+++ b/touchdown/aws/vpc/vpn_gateway.py
@@ -66,6 +66,7 @@ class Describe(SimpleDescribe, Plan):
 
     resource = VpnGateway
     service_name = 'ec2'
+    api_version = '2015-10-01'
     describe_action = "describe_vpn_gateways"
     describe_envelope = "VpnGateways"
     key = "VpnGatewayId"

--- a/touchdown/aws/waf/byte_match.py
+++ b/touchdown/aws/waf/byte_match.py
@@ -90,6 +90,7 @@ class Describe(WafDescribe, Plan):
 
     resource = ByteMatchSet
     service_name = 'waf'
+    api_version = '2015-08-24'
     describe_action = "list_byte_match_sets"
     describe_envelope = "ByteMatchSets"
     annotate_action = "get_byte_match_set"

--- a/touchdown/aws/waf/ip_set.py
+++ b/touchdown/aws/waf/ip_set.py
@@ -52,6 +52,7 @@ class Describe(WafDescribe, Plan):
 
     resource = IpSet
     service_name = 'waf'
+    api_version = '2015-08-24'
     describe_action = "list_ip_sets"
     describe_envelope = "IPSets"
     annotate_action = "get_ip_set"

--- a/touchdown/aws/waf/rule.py
+++ b/touchdown/aws/waf/rule.py
@@ -71,6 +71,7 @@ class Describe(WafDescribe, Plan):
 
     resource = Rule
     service_name = 'waf'
+    api_version = '2015-08-24'
     describe_action = "list_rules"
     describe_envelope = "Rules"
     annotate_action = "get_rule"

--- a/touchdown/aws/waf/web_acl.py
+++ b/touchdown/aws/waf/web_acl.py
@@ -61,6 +61,7 @@ class Describe(WafDescribe, Plan):
 
     resource = WebACL
     service_name = 'waf'
+    api_version = '2015-08-24'
     describe_action = "list_web_acls"
     describe_envelope = "WebACLs"
     annotate_action = "get_web_acl"

--- a/touchdown/tests/test_aws_common.py
+++ b/touchdown/tests/test_aws_common.py
@@ -57,7 +57,9 @@ class TestSimpleDescribeImplementations(unittest.TestCase):
             if getattr(impl, "describe_action", None) is None:
                 continue
 
-            service = session.get_service_model(impl.service_name)
+            assert len(impl.api_version or '') == 10, '{} is not versioned'.format(impl)
+
+            service = session.get_service_model(impl.service_name, impl.api_version)
             methods = {xform_name(s): s for s in service.operation_names}
             operation = service.operation_model(methods[impl.describe_action])
 


### PR DESCRIPTION
Previously touchdown used to use the latest available version in botocore, but that could cause incompatibility with new versions of botocore. They are now frozen so touchdown should continue to work with new botocore releases.

This updates the metadata checking test case to assert that *all* services use a API version and that it is a valid version.