### PR TITLE
AWS Events: All targets must be deleted before removing an event

### DIFF
--- a/touchdown/aws/events/rule.py
+++ b/touchdown/aws/events/rule.py
@@ -153,3 +153,15 @@ class Apply(SimpleApply, Describe):
 class Destroy(SimpleDestroy, Describe):
 
     destroy_action = "delete_rule"
+
+    def destroy_object(self):
+        for remote in self.object.get("Targets", []):
+            yield self.generic_action(
+                ['Remove old target {}'.format(remote['Id'])],
+                self.client.remove_targets,
+                Rule=self.resource.name,
+                Ids=[remote['Id']],
+            )
+
+        for action in super(Destroy, self).destroy_object():
+            yield action

--- a/touchdown/tests/stubs/aws/__init__.py
+++ b/touchdown/tests/stubs/aws/__init__.py
@@ -14,6 +14,7 @@
 
 from .bucket import BucketStubber
 from .ec2_instance import EC2InstanceStubber
+from .event_rule import EventRuleStubber
 from .volume_attachment import VolumeAttachmentStubber
 from .volume import VolumeStubber
 
@@ -21,6 +22,7 @@ from .volume import VolumeStubber
 __all__ = [
     'BucketStubber',
     'EC2InstanceStubber',
+    'EventRuleStubber',
     'VolumeAttachmentStubber',
     'VolumeStubber',
 ]

--- a/touchdown/tests/stubs/aws/event_rule.py
+++ b/touchdown/tests/stubs/aws/event_rule.py
@@ -1,0 +1,76 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .service import ServiceStubber
+
+
+class EventRuleStubber(ServiceStubber):
+
+    client_service = 'events'
+
+    def add_list_rules_empty_response(self):
+        return self.add_response(
+            'list_rules',
+            service_response={
+                'Rules': [],
+            },
+            expected_params={
+                'NamePrefix': self.resource.name,
+            },
+        )
+
+    def add_list_rules_one_response_by_name(self):
+        return self.add_response(
+            'list_rules',
+            service_response={
+                'Rules': [{
+                    'Name': self.resource.name,
+                }],
+            },
+            expected_params={
+                'NamePrefix': self.resource.name,
+            },
+        )
+
+    def add_list_targets_by_rule(self, targets):
+        return self.add_response(
+            'list_targets_by_rule',
+            service_response={
+                'Targets': targets,
+            },
+            expected_params={
+                'Rule': self.resource.name,
+            },
+        )
+
+    def add_remove_targets(self, target_ids):
+        return self.add_response(
+            'remove_targets',
+            service_response={
+            },
+            expected_params={
+                'Rule': self.resource.name,
+                'Ids': target_ids,
+            },
+        )
+
+    def add_delete_rule(self):
+        return self.add_response(
+            'delete_rule',
+            service_response={
+            },
+            expected_params={
+                'Name': self.resource.name,
+            },
+        )

--- a/touchdown/tests/test_aws_events_rule.py
+++ b/touchdown/tests/test_aws_events_rule.py
@@ -1,0 +1,57 @@
+# Copyright 2016 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from touchdown.tests.aws import StubberTestCase
+from touchdown.tests.stubs.aws import EventRuleStubber
+
+
+class TestRuleDeletion(StubberTestCase):
+
+    def test_delete_rule(self):
+        goal = self.create_goal('destroy')
+
+        rule = self.fixtures.enter_context(EventRuleStubber(
+            goal.get_service(
+                self.aws.add_event_rule(
+                    name='my-rule',
+                ),
+                'destroy',
+            )
+        ))
+        rule.add_list_rules_one_response_by_name()
+        rule.add_list_targets_by_rule([
+            {'Id': 'SomeTargetId', 'Arn': 'some:arn:12345'},
+            {'Id': 'SomeTargetId2', 'Arn': 'some:arn:12345'},
+        ])
+        rule.add_remove_targets(['SomeTargetId'])
+        rule.add_remove_targets(['SomeTargetId2'])
+        rule.add_delete_rule()
+
+        goal.execute()
+
+    def test_delete_rule_idempotent(self):
+        goal = self.create_goal('destroy')
+
+        rule = self.fixtures.enter_context(EventRuleStubber(
+            goal.get_service(
+                self.aws.add_event_rule(
+                    name='my-rule',
+                ),
+                'destroy',
+            )
+        ))
+        rule.add_list_rules_empty_response()
+
+        self.assertEqual(len(list(goal.plan())), 0)
+        self.assertEqual(len(goal.get_changes(rule.resource)), 0)


### PR DESCRIPTION
You can't delete an event rule while it is still connected to targets.