### PR TITLE
AWS: The destroy plan fails sometimes fails in an empty state.

### DIFF
--- a/touchdown/aws/common.py
+++ b/touchdown/aws/common.py
@@ -568,6 +568,10 @@ class SimpleDestroy(SimpleDescribe):
     def get_actions(self):
         self.object = self.describe_object()
 
+        if 'never-destroy' in self.resource.ensure:
+            logger.debug('Resource "{}" not considered for deletion due to ensure policy'.format(resource))
+            return
+
         if not self.object:
             logger.debug('Resource "{}" not found - assuming already destroyed'.format(self.resource))
             return

--- a/touchdown/goals/destroy.py
+++ b/touchdown/goals/destroy.py
@@ -24,9 +24,7 @@ class Destroy(ActionGoalMixin, Goal):
     execute_in_reverse = True
 
     def get_plan_class(self, resource):
-        if 'never-destroy' not in resource.ensure:
-            return resource.meta.get_plan('destroy') or resource.meta.get_plan('describe') or resource.meta.get_plan('null')
-        return resource.meta.get_plan('describe') or resource.meta.get_plan('null')
+        return resource.meta.get_plan('destroy') or resource.meta.get_plan('describe') or resource.meta.get_plan('null')
 
 
 register(Destroy)

--- a/touchdown/tests/test_aws_s3_bucket.py
+++ b/touchdown/tests/test_aws_s3_bucket.py
@@ -82,6 +82,49 @@ class TestBucketCreation(StubberTestCase):
 
 class TestBucketDeletion(StubberTestCase):
 
+    def test_delete_bucket_forbidden(self):
+        # If a bucket is marked as never-destroy then it's destroy plan is
+        # still used, but it should never harm it
+        goal = self.create_goal('destroy')
+
+        bucket = self.fixtures.enter_context(BucketStubber(
+            goal.get_service(
+                self.aws.add_bucket(
+                    name='my-bucket',
+                    ensure=['never-destroy'],
+                ),
+                'destroy',
+            )
+        ))
+
+        bucket.add_list_buckets_one_response()
+        bucket.add_head_bucket()
+        bucket.add_get_bucket_location()
+        bucket.add_get_bucket_cors()
+        bucket.add_get_bucket_policy()
+        bucket.add_get_bucket_notification_configuration()
+        bucket.add_get_bucket_accelerate_configuration()
+
+        self.assertRaises(errors.NothingChanged, goal.execute)
+
+    def test_delete_bucket_forbidden_not_found(self):
+        # If a bucket is marked as never-destroy then it's destroy plan is
+        # still used, but it should never harm it
+        goal = self.create_goal('destroy')
+
+        bucket = self.fixtures.enter_context(BucketStubber(
+            goal.get_service(
+                self.aws.add_bucket(
+                    name='my-bucket',
+                    ensure=['never-destroy'],
+                ),
+                'destroy',
+            )
+        ))
+        bucket.add_list_buckets_empty_response()
+
+        self.assertRaises(errors.NothingChanged, goal.execute)
+
     def test_delete_bucket(self):
         goal = self.create_goal('destroy')
 


### PR DESCRIPTION
Resources marked as `never-destroy` are 'described', but it is fatal for a thing to be described and not there. The destroy policy should **always** be used and it should decide not to proceed.

Todo:

  * [ ] This change impacts a lot of tests which are tricky to fix nicely - they use fixtures and they get their (botocore stubbed) client from the describe plan. The correct fix is probably to have a service that returns a client for a resource, rather than having a separate client for describe/destroy/apply.