### PR TITLE
Restore the ssh parameter quotes munged by flake8-quote

### DIFF
--- a/touchdown/ssh/terminal.py
+++ b/touchdown/ssh/terminal.py
@@ -33,8 +33,8 @@ class SshMixin(object):
         kwargs = serializers.Resource().render(self.runner, self.resource)
         cmd = [
             '/usr/bin/ssh',
-            '-o', 'User=\'{username}\''.format(**kwargs),
-            '-o', 'Port=\'{port}\''.format(**kwargs),
+            '-o', 'User="{username}"'.format(**kwargs),
+            '-o', 'Port="{port}"'.format(**kwargs),
             '-W', '%h:%p',
             kwargs['hostname'],
         ]
@@ -44,9 +44,9 @@ class SshMixin(object):
         kwargs = serializers.Resource().render(self.runner, self.resource)
         cmd = [
             self.get_command(),
-            '-o', 'User=\'{username}\''.format(**kwargs),
-            '-o', 'Port={port}'.format(**kwargs),
-            '-o', 'HostName={hostname}'.format(**kwargs),
+            '-o', 'User="{username}"'.format(**kwargs),
+            '-o', 'Port="{port}"'.format(**kwargs),
+            '-o', 'HostName="{hostname}"'.format(**kwargs),
         ]
         if self.resource.proxy:
             proxy = self.runner.get_plan(self.resource.proxy)

--- a/touchdown/tests/test_aws_ec2_auto_scaling_group.py
+++ b/touchdown/tests/test_aws_ec2_auto_scaling_group.py
@@ -389,9 +389,9 @@ class TestSshAutoScalingGroup(StubberTestCase):
         self.assertEqual(ssh_connection.get_command(), '/usr/bin/ssh')
         self.assertEqual(ssh_connection.get_command_and_args(), [
             '/usr/bin/ssh',
-            '-o', 'User=\'root\'',
-            '-o', 'Port=22',
-            '-o', 'HostName=8.8.8.8',
+            '-o', 'User="root"',
+            '-o', 'Port="22"',
+            '-o', 'HostName="8.8.8.8"',
             'remote',
         ])
 
@@ -512,10 +512,10 @@ class TestSshAutoScalingGroup(StubberTestCase):
 
         self.assertEqual(ssh_connection_2.get_command_and_args(), [
             '/usr/bin/ssh',
-            '-o', 'User=\'root\'',
-            '-o', 'Port=22',
-            '-o', 'HostName=10.0.0.1',
-            '-o', 'ProxyCommand=/usr/bin/ssh -o User=\'root\' -o Port=\'22\' -W %h:%p 8.8.8.8',
+            '-o', 'User="root"',
+            '-o', 'Port="22"',
+            '-o', 'HostName="10.0.0.1"',
+            '-o', 'ProxyCommand=/usr/bin/ssh -o User="root" -o Port="22" -W %h:%p 8.8.8.8',
             'remote',
         ])
 
@@ -616,9 +616,9 @@ class TestSshAutoScalingGroup(StubberTestCase):
 
         self.assertEqual(ssh_connection_2.get_command_and_args(), [
             '/usr/bin/ssh',
-            '-o', 'User=\'root\'',
-            '-o', 'Port=22',
-            '-o', 'HostName=10.0.0.42',
-            '-o', 'ProxyCommand=/usr/bin/ssh -o User=\'root\' -o Port=\'22\' -W %h:%p 8.8.8.8',
+            '-o', 'User="root"',
+            '-o', 'Port="22"',
+            '-o', 'HostName="10.0.0.42"',
+            '-o', 'ProxyCommand=/usr/bin/ssh -o User="root" -o Port="22" -W %h:%p 8.8.8.8',
             'remote',
         ])


### PR DESCRIPTION
Possibly don't even need them, but prevents simple breakage of command line.