### PR TITLE
Changed instance profile spec for EC2 instance to be a dict

### DIFF
--- a/touchdown/aws/ec2/instance.py
+++ b/touchdown/aws/ec2/instance.py
@@ -53,7 +53,14 @@ class Instance(Resource):
     instance_type = argument.String(field='InstanceType')
     key_pair = argument.Resource(KeyPair, field='KeyName')
     subnet = argument.Resource(Subnet, field='SubnetId')
-    instance_profile = argument.Resource(InstanceProfile, field='IamInstanceProfile')
+    instance_profile = argument.Resource(
+        InstanceProfile,
+        field='IamInstanceProfile',
+        serializer=serializers.Dict(
+            Arn=serializers.Property('Arn'),
+            Name=serializers.Property('InstanceProfileName')
+        )
+    )
 
     user_data = argument.String(field='UserData')
 

--- a/touchdown/tests/fixtures/aws/__init__.py
+++ b/touchdown/tests/fixtures/aws/__init__.py
@@ -14,6 +14,7 @@
 
 from .bucket import BucketFixture
 from .customer_gateway import CustomerGatewayFixture
+from .instance_profile import InstanceProfileFixture
 from .launch_configuration import LaunchConfigurationFixture
 from .network_acl import NetworkAclFixture
 from .rest_api import RestApiFixture

--- a/touchdown/tests/fixtures/aws/__init__.py
+++ b/touchdown/tests/fixtures/aws/__init__.py
@@ -28,6 +28,7 @@ from .vpn_gateway import VpnGatewayFixture
 __all__ = [
     'BucketFixture',
     'CustomerGatewayFixture',
+    'InstanceProfileFixture',
     'LaunchConfigurationFixture',
     'NetworkAclFixture',
     'RestApiFixture',

--- a/touchdown/tests/fixtures/aws/instance_profile.py
+++ b/touchdown/tests/fixtures/aws/instance_profile.py
@@ -1,0 +1,32 @@
+# Copyright 2017 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from touchdown.tests.stubs.aws import InstanceProfileStubber
+
+from .fixture import AwsFixture
+
+class InstanceProfileFixture(AwsFixture):
+
+    def __enter__(self):
+        self.profile = self.fixtures.enter_context(InstanceProfileStubber(
+            self.goal.get_service(
+                self.aws.get_instance_profile(
+                    name='my-test-profile',
+                ),
+                'describe',
+            ),
+        ))
+        self.profile.add_list_instance_profile_one_response()
+
+        return self.profile.resource

--- a/touchdown/tests/fixtures/aws/instance_profile.py
+++ b/touchdown/tests/fixtures/aws/instance_profile.py
@@ -16,6 +16,7 @@ from touchdown.tests.stubs.aws import InstanceProfileStubber
 
 from .fixture import AwsFixture
 
+
 class InstanceProfileFixture(AwsFixture):
 
     def __enter__(self):

--- a/touchdown/tests/stubs/aws/ec2_instance.py
+++ b/touchdown/tests/stubs/aws/ec2_instance.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from .service import ServiceStubber
-from .instance_profile import InstanceProfileStubber
 
 
 class EC2InstanceStubber(ServiceStubber):

--- a/touchdown/tests/stubs/aws/ec2_instance.py
+++ b/touchdown/tests/stubs/aws/ec2_instance.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .service import ServiceStubber
+from .instance_profile import InstanceProfileStubber
 
 
 class EC2InstanceStubber(ServiceStubber):
@@ -72,6 +73,26 @@ class EC2InstanceStubber(ServiceStubber):
                 }],
             },
             expected_params={
+                'BlockDeviceMappings': [],
+                'MaxCount': 1,
+                'MinCount': 1,
+                'ImageId': 'foobarbaz',
+            },
+        )
+
+    def add_run_instance_with_profile(self):
+        return self.add_response(
+            'run_instances',
+            service_response={
+                'Instances': [{
+                    'InstanceId': self.make_id(self.resource.name),
+                }],
+            },
+            expected_params={
+                'IamInstanceProfile': {
+                    'Name': 'my-test-profile',
+                    'Arn': '90a968bd192ecc426bafad9eae40504de04e9837',
+                },
                 'BlockDeviceMappings': [],
                 'MaxCount': 1,
                 'MinCount': 1,

--- a/touchdown/tests/test_aws_ec2_instance.py
+++ b/touchdown/tests/test_aws_ec2_instance.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from touchdown.tests.aws import StubberTestCase
-from touchdown.tests.stubs.aws import EC2InstanceStubber, InstanceProfileStubber
+from touchdown.tests.stubs.aws import EC2InstanceStubber
 from .fixtures.aws import InstanceProfileFixture
 
 


### PR DESCRIPTION
Spec for creating an EC2 instance has an Instance Profile defined with a dict not a string representation like in a launch configuration.