### PR TITLE
Use Name and not Arn for instance profile in RunInstances

### DIFF
--- a/touchdown/aws/ec2/instance.py
+++ b/touchdown/aws/ec2/instance.py
@@ -57,7 +57,6 @@ class Instance(Resource):
         InstanceProfile,
         field='IamInstanceProfile',
         serializer=serializers.Dict(
-            Arn=serializers.Property('Arn'),
             Name=serializers.Property('InstanceProfileName')
         )
     )

--- a/touchdown/tests/stubs/aws/ec2_instance.py
+++ b/touchdown/tests/stubs/aws/ec2_instance.py
@@ -90,7 +90,6 @@ class EC2InstanceStubber(ServiceStubber):
             expected_params={
                 'IamInstanceProfile': {
                     'Name': 'my-test-profile',
-                    'Arn': '90a968bd192ecc426bafad9eae40504de04e9837',
                 },
                 'BlockDeviceMappings': [],
                 'MaxCount': 1,


### PR DESCRIPTION
InstanceProfileName and InstanceProfileArn cannot be used together for the InstanceProfile parameter of RunInstances. Have changed to just just InstanceProfileName instead. I'm not sure if you could ever create an instance profile without a name, and therefore *need* to use the ARN.