### PR TITLE
Support VPC DNS attributes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-botocore==1.4.28
+botocore==1.5.0
 jmespath==0.9.0
 netaddr==0.7.18
 contextlib2==0.5.3

--- a/touchdown/goals/portfwd.py
+++ b/touchdown/goals/portfwd.py
@@ -95,4 +95,5 @@ class PortForward(Goal):
         self.ui.echo('All requested port forwards started. Waiting for connections...')
         self.process_incoming_forever(servers)
 
+
 register(PortForward)

--- a/touchdown/tests/fixtures/aws/vpc.py
+++ b/touchdown/tests/fixtures/aws/vpc.py
@@ -30,6 +30,7 @@ class VpcFixture(AwsFixture):
             ),
         ))
         self.vpc_stubber.add_describe_vpcs_one_response_by_name()
+        self.vpc_stubber.add_describe_vpc_attributes()
 
         self.vpc = self.vpc_stubber.resource
         self.vpc_id = self.vpc_stubber.make_id(self.vpc.name)

--- a/touchdown/tests/stubs/aws/vpc.py
+++ b/touchdown/tests/stubs/aws/vpc.py
@@ -90,7 +90,7 @@ class VpcStubber(ServiceStubber):
             expected_params={
                 'VpcId': self.make_id(self.resource.name),
                 'EnableDnsSupport': {
-                    'Value': True
+                    'Value': False
                 }
             },
         )
@@ -104,7 +104,7 @@ class VpcStubber(ServiceStubber):
             expected_params={
                 'VpcId': self.make_id(self.resource.name),
                 'EnableDnsHostnames': {
-                    'Value': False
+                    'Value': True
                 }
             },
         )

--- a/touchdown/tests/stubs/aws/vpc.py
+++ b/touchdown/tests/stubs/aws/vpc.py
@@ -51,6 +51,64 @@ class VpcStubber(ServiceStubber):
             },
         )
 
+    def add_describe_vpc_attributes(self):
+        self.add_response(
+            'describe_vpc_attribute',
+            service_response={
+                'EnableDnsSupport': {
+                    'Value': True
+                },
+                'VpcId': self.make_id(self.resource.name),
+            },
+            expected_params={
+                'VpcId': self.make_id(self.resource.name),
+                'Attribute': 'enableDnsSupport',
+            },
+        )
+        return self.add_response(
+            'describe_vpc_attribute',
+            service_response={
+                'EnableDnsHostnames': {
+                    'Value': False
+                },
+                'VpcId': self.make_id(self.resource.name),
+            },
+            expected_params={
+                'VpcId': self.make_id(self.resource.name),
+                'Attribute': 'enableDnsHostnames',
+            },
+        )
+
+    def add_modify_vpc_attributes(self):
+        self.add_response(
+            'modify_vpc_attribute',
+            service_response={
+                'ResponseMetadata': {
+                    '...': '...',
+                },
+            },
+            expected_params={
+                'VpcId': self.make_id(self.resource.name),
+                'EnableDnsSupport': {
+                    'Value': True
+                }
+            },
+        )
+        return self.add_response(
+            'modify_vpc_attribute',
+            service_response={
+                'ResponseMetadata': {
+                    '...': '...',
+                },
+            },
+            expected_params={
+                'VpcId': self.make_id(self.resource.name),
+                'EnableDnsHostnames': {
+                    'Value': False
+                }
+            },
+        )
+
     def add_create_vpc(self):
         return self.add_response(
             'create_vpc',
@@ -68,7 +126,7 @@ class VpcStubber(ServiceStubber):
 
     def add_create_tags(self, **tags):
         tag_list = [{'Key': k, 'Value': v} for (k, v) in tags.items()]
-        self.add_response(
+        return self.add_response(
             'create_tags',
             service_response={
             },

--- a/touchdown/tests/test_aws_account.py
+++ b/touchdown/tests/test_aws_account.py
@@ -49,5 +49,7 @@ class TestAccount(StubberTestCase):
         ))
         self.assertEqual(goal.get_service(vpcf.vpc, 'describe').describe_object(), {
             'VpcId': vpcf.vpc_id,
+            'EnableDnsHostnames': {'Value': False},
+            'EnableDnsSupport': {'Value': True},
             'State': 'available',
         })

--- a/touchdown/tests/test_aws_external_account.py
+++ b/touchdown/tests/test_aws_external_account.py
@@ -52,5 +52,7 @@ class TestExternalAccount(StubberTestCase):
         ))
         self.assertEqual(goal.get_service(vpcf.vpc, 'describe').describe_object(), {
             'VpcId': vpcf.vpc_id,
+            'EnableDnsHostnames': {'Value': False},
+            'EnableDnsSupport': {'Value': True},
             'State': 'available',
         })

--- a/touchdown/tests/test_aws_vpc_vpc.py
+++ b/touchdown/tests/test_aws_vpc_vpc.py
@@ -37,11 +37,14 @@ class TestVpcCreation(StubberTestCase):
 
         # Wait for VPC to exist
         vpc.add_describe_vpcs_empty_response_by_name()
+
         vpc.add_describe_vpcs_one_response_by_name(state='pending')
+
         vpc.add_describe_vpcs_one_response_by_name()
 
         # Check it really does exist, gather more info about it and carry on
         vpc.add_describe_vpcs_one_response_by_name()
+        vpc.add_describe_vpc_attributes()
 
         goal.execute()
 
@@ -59,6 +62,7 @@ class TestVpcCreation(StubberTestCase):
         ))
 
         vpc.add_describe_vpcs_one_response_by_name()
+        vpc.add_describe_vpc_attributes()
 
         self.assertEqual(len(list(goal.plan())), 0)
         self.assertEqual(len(goal.get_changes(vpc.resource)), 0)
@@ -80,6 +84,7 @@ class TestVpcDestroy(StubberTestCase):
         ))
 
         vpc.add_describe_vpcs_one_response_by_name()
+        vpc.add_describe_vpc_attributes()
         vpc.add_delete_vpc()
 
         goal.execute()

--- a/touchdown/tests/test_aws_vpc_vpc.py
+++ b/touchdown/tests/test_aws_vpc_vpc.py
@@ -67,6 +67,27 @@ class TestVpcCreation(StubberTestCase):
         self.assertEqual(len(list(goal.plan())), 0)
         self.assertEqual(len(goal.get_changes(vpc.resource)), 0)
 
+    def test_modify_vpc(self):
+        goal = self.create_goal('apply')
+
+        vpc = self.fixtures.enter_context(VpcStubber(
+            goal.get_service(
+                self.aws.add_vpc(
+                    name='test-vpc',
+                    cidr_block='192.168.0.0/26',
+                    enable_dns_support=False,
+                    enable_dns_hostnames=True,
+                ),
+                'apply',
+            )
+        ))
+
+        vpc.add_describe_vpcs_one_response_by_name()
+        vpc.add_describe_vpc_attributes()
+        vpc.add_modify_vpc_attributes()
+
+        goal.execute()
+
 
 class TestVpcDestroy(StubberTestCase):
 


### PR DESCRIPTION
Add support for modifying DNS resolution support and DNS hostname provision on VPCs

They are handled separately as botocore only lets you modify one at a time.